### PR TITLE
Added local configuration for Hugging Face cache directory

### DIFF
--- a/Dockerfile.zh
+++ b/Dockerfile.zh
@@ -1,0 +1,17 @@
+FROM python:3.12
+
+WORKDIR /app
+
+RUN sed -i 's/deb.debian.org/mirrors.huaweicloud.com/g' /etc/apt/sources.list.d/debian.sources
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+
+RUN pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+
+RUN apt-get update && apt-get install -y libgl1
+
+RUN pip install .
+
+CMD ["pdf2zh", "-i"]

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -91,6 +91,14 @@
       ```bash
       pip install pdf2zh
       ```
+2.1 本地运行最新代码
+
+      ```bash
+      git clone https://github.com/Byaidu/PDFMathTranslate.git
+      cd PDFMathTranslate
+      pip install -e .
+      pdf2zh -i
+      ```
 
 3. 开始在浏览器中使用：
 

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -17,6 +17,13 @@ import requests
 
 from pdf2zh import __version__
 
+## set huggingface home
+HF_HOME = os.getcwd() + "/hf_home"
+## if not exists, create it
+if not os.path.exists(HF_HOME):
+    os.makedirs(HF_HOME)
+print(f"HF_HOME: {HF_HOME}")
+os.environ["HF_HOME"] = HF_HOME
 
 def check_files(files: List[str]) -> List[str]:
     files = [


### PR DESCRIPTION
## Changes
Added local configuration for Hugging Face cache directory

### Details
- Set `HF_HOME` environment variable to `hf_home` subdirectory under current working directory
- Automatically create the directory if it doesn't exist
- Print `HF_HOME` path for debugging purposes

### Rationale
- Avoid Hugging Face models and cache files being saved in user's home directory by default
- Keep project dependencies and cache files contained within project directory for better management
- Helps maintain consistent file structure across different environments

### Impact
- All Hugging Face related downloads and cache will be stored in project's `hf_home` directory
- Does not affect Hugging Face configurations for other system projects