### PR TITLE
修复腾讯翻译遇到空字符报错的问题。

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -170,13 +170,13 @@ class TencentTranslator(BaseTranslator):
         # 2. Result test
         try:
             result = result["Response"]["TargetText"]
-            return result
+            # return result
         except KeyError:
             result = ""
-            raise ValueError("No valid key in Tencent's response")
-        # 3. Result length check
-        if len(result) == 0:
-            raise ValueError("Empty translation result")
+        #     raise ValueError("No valid key in Tencent's response")
+        # # 3. Result length check
+        # if len(result) == 0:
+        #     raise ValueError("Empty translation result")
         return result
 
 


### PR DESCRIPTION
修复了腾讯翻译遇到空字符时的判断，当获取的返回信息不是翻译相关的信息时，全部返回空字符串。