### PR TITLE
Fix error when using the `mat` method with NumPy version >= 2.0.0.

### DIFF
--- a/pdf2zh/pdfinterp.py
+++ b/pdf2zh/pdfinterp.py
@@ -229,7 +229,11 @@ class PDFPageInterpreterEx(PDFPageInterpreter):
                 self.device.fontmap = interpreter.fontmap
                 ops_new = self.device.end_figure(xobjid)
                 ctm_inv = np.linalg.inv(np.array(ctm[:4]).reshape(2, 2))
-                pos_inv = -np.mat(ctm[4:]) * ctm_inv
+                np_version = np.__version__
+                if np_version.split(".")[0] >= "2":
+                    pos_inv = -np.asmatrix(ctm[4:]) * ctm_inv
+                else:
+                    pos_inv = -np.mat(ctm[4:]) * ctm_inv
                 a, b, c, d = ctm_inv.reshape(4).tolist()
                 e, f = pos_inv.tolist()[0]
                 self.obj_patch[self.xobjmap[xobjid].objid] = (


### PR DESCRIPTION
可能与 #206 相关

参考文件 : https://numpy.org/doc/2.2/numpy_2_0_migration_guide.html

由于numpy2 版本后有许多不相容的变化,导致使用mat会丢出例外, 最后pdf可能没被成功处理

以下修改后 #206 提供文件的测试截图
![圖片](https://github.com/user-attachments/assets/adffe2a8-7ad5-4d1c-94a7-2231ad128b3d)
