### PR TITLE
Fixed an issue causing an infinite loop when an error occurs during translation.

### DIFF
--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -205,6 +205,8 @@ def translate_file(
     except CancelledError:
         del cancellation_event_map[session_id]
         raise gr.Error("Translation cancelled")
+    except Exception as e:
+        raise gr.Error(f"Translation failed: {e}")
     print(f"Files after translation: {os.listdir(output)}")
 
     if not file_mono.exists() or not file_dual.exists():


### PR DESCRIPTION
This bug can be easily reproduced by following these steps:
1. Select `Deeplx` as the translator.  
2. Set an invalid endpoint, such as `http://api.deeplx.xx/`.  
3. The application will enter an infinite retry loop, which cannot be stopped.  

![圖片](https://github.com/user-attachments/assets/83e003fb-8737-46e7-8d61-cb0ae2b5af24)

This change sets the maximum retry count to 3 and handles exceptions if the error persists.
