### PR TITLE
add docker-compose.yml and add entrypoint.sh to support env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN uv pip install --system --no-cache . && \
     cp ./scripts/entrypoint.sh /entrypoint.sh && \
     chmod +x /entrypoint.sh
 
-ENV  PDF2ZH_THREADS=1 PDF2ZH_SOURCE_LANG=en PDF2ZH_TARGET_LANG=zh\
-     PDF2ZH_OTHER_ARGS=""  PDF2ZH_AUTH_FILE="" 
+ENV  PDF2ZH_THREADS=1 PDF2ZH_SOURCE_LANG=en PDF2ZH_TARGET_LANG=zh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update && \
 
 COPY . .
 
-RUN uv pip install --system --no-cache .
+RUN uv pip install --system --no-cache . && \
+    cp ./scripts/entrypoint.sh /entrypoint.sh && \
+    chmod +x /entrypoint.sh
 
-CMD ["pdf2zh", "-i"]
+ENV  PDF2ZH_THREADS=1 PDF2ZH_SOURCE_LANG=en PDF2ZH_TARGET_LANG=zh\
+     PDF2ZH_OTHER_ARGS=""  PDF2ZH_AUTH_FILE="" 
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ RUN uv pip install --system --no-cache . && \
 
 ENV  PDF2ZH_THREADS=1 PDF2ZH_SOURCE_LANG=en PDF2ZH_TARGET_LANG=zh
 
+# Add HEALTHCHECK using curl to verify service health
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 CMD curl -f http://localhost:7860 || exit 1
+
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ For docker deployment on cloud service:
 
 </details>
 
+<details>
+  <summary>5. Docker Compose</summary>
+
+1. Copy the contents from [docker-compose.yml](./docker-compose.yml) to your project.
+
+2. Set up the environment variables in the `docker-compose.yml` file as per your configuration.
+
+3. Run the command `docker compose up -d` to start your instance.
+
+</details>
+
 ### Unable to install?
 
 The present program needs an AI model(`wybxc/DocLayout-YOLO-DocStructBench-onnx`) before working and some users are not able to download due to network issues. If you have a problem with downloading this model, we provide a workaround using the following environment variable:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  pdf2zh:
+    image: byaidu/pdf2zh:${PDF2ZH_VERSION:-latest}
+    container_name: ${PDF2ZH_CONTAINER_NAME:-pdf2zh}
+    hostname: ${PDF2ZH_HOSTNAME:-pdf2zh}
+    restart: always
+    ports:
+      - 7860:7860
+    environment:
+      HF_ENDPOINT: https://hf-mirror.com # if you don't want to use the mirror, rm this line
+    volumes:
+      - ${PDF2ZH_DATA_DIR:-./data}/files:/app/pdf2zh_files # the directory to store the files
+      - ${PDF2ZH_DATA_DIR:-./data}/hf:/root/.cache/huggingface # if you want to keep the model cache at the host
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - 7860:7860
     environment:
       HF_ENDPOINT: https://hf-mirror.com  # if you don't want to use the mirror, rm this line
-      PDF2ZH_DEBUG: false                 # true to enable debug mode
+      PDF2ZH_DEBUG: false                 # true or 1 or yes to enable debug mode, case insensitive
       PDF2ZH_THREADS: 1                   # how many threads to use in translation:
       PDF2ZH_SOURCE_LANG: en              # the source language
       PDF2ZH_TARGET_LANG: zh              # the target language

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,12 @@ services:
     ports:
       - 7860:7860
     environment:
-      HF_ENDPOINT: https://hf-mirror.com # if you don't want to use the mirror, rm this line
+      HF_ENDPOINT: https://hf-mirror.com  # if you don't want to use the mirror, rm this line
+      PDF2ZH_THREADS: 2                   # how many threads to use in translation:
+      PDF2ZH_SOURCE_LANG: en              # the source language
+      PDF2ZH_TARGET_LANG: zh              # the target language
+      PDF2ZH_AUTH_FILE: ""                # the path to the auth file, you should mount it to the container
+      PDF2ZH_OTHER_ARGS: ""               # other arguments to pass to the pdf2zh command, or you can use the command line
     volumes:
       - ${PDF2ZH_DATA_DIR:-./data}/files:/app/pdf2zh_files # the directory to store the files
       - ${PDF2ZH_DATA_DIR:-./data}/hf:/root/.cache/huggingface # if you want to keep the model cache at the host

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,17 @@ services:
       - 7860:7860
     environment:
       HF_ENDPOINT: https://hf-mirror.com  # if you don't want to use the mirror, rm this line
-      PDF2ZH_THREADS: 2                   # how many threads to use in translation:
+      PDF2ZH_DEBUG: false                 # true to enable debug mode
+      PDF2ZH_THREADS: 1                   # how many threads to use in translation:
       PDF2ZH_SOURCE_LANG: en              # the source language
       PDF2ZH_TARGET_LANG: zh              # the target language
-      PDF2ZH_AUTH_FILE: ""                # the path to the auth file, you should mount it to the container
       PDF2ZH_OTHER_ARGS: ""               # other arguments to pass to the pdf2zh command, or you can use the command line
+
+      # the following are for the authentication. ! but now, it doesn't work because pdf2zh parsing the arguments in the wrong way.
+      PDF2ZH_AUTH_USER: ""                # the username for the authentication
+      PDF2ZH_AUTH_PASS: ""                # the password for the authentication
+      PDF2ZH_AUTH_USER_FILE: ""           # the path to the file containing the username for the authentication
+      PDF2ZH_AUTH_PASS_FILE: ""           # the path to the file containing the password for the authentication, the line number should be the same as the username
     volumes:
       - ${PDF2ZH_DATA_DIR:-./data}/files:/app/pdf2zh_files # the directory to store the files
       - ${PDF2ZH_DATA_DIR:-./data}/hf:/root/.cache/huggingface # if you want to keep the model cache at the host

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,11 +1,71 @@
 #!/bin/env bash
 
 ENV_PREFIX="PDF2ZH_"
-ENV_LIST=(THREADS SOURCE_LANG TARGET_LANG AUTH_FILE)
-ENV_LIST_ARGS=(-t -li -lo --authorized)
+ENV_LIST=(THREADS SOURCE_LANG TARGET_LANG)
+ENV_LIST_ARGS=(--thread --lang-in --lang-out)
 
-
+# define the default values
 _tmp_args=""
+
+# Handle for auth
+_auth_dir="$HOME/.auth"
+_auth_user_file="$_auth_dir/user"
+_auth_pass_file="$_auth_dir/pass"
+_auth_enabled=false
+
+echo "=================================================="
+# Create the auth directory if it does not exist
+mkdir -p "$_auth_dir" || { echo "Error: Failed to create directory $_auth_dir"; exit 1; }
+
+# Check if user and password are set via environment variables
+if [ -n "$PDF2ZH_AUTH_USER" ] && [ -n "$PDF2ZH_AUTH_PASS" ]; then
+    echo -e "$PDF2ZH_AUTH_USER\n" > "$_auth_user_file"
+    echo -e "$PDF2ZH_AUTH_PASS\n" > "$_auth_pass_file"
+    _auth_enabled=true
+    # Clear sensitive variables immediately after use
+    unset PDF2ZH_AUTH_USER PDF2ZH_AUTH_PASS
+fi
+
+# Check if additional auth files are specified and valid
+_auth_user_file_valid=false
+_auth_pass_file_valid=false
+
+if [ -n "$PDF2ZH_AUTH_USER_FILE" ] && [ -f "$PDF2ZH_AUTH_USER_FILE" ]; then
+    _user_lines=$(awk 'END {print NR}' "$PDF2ZH_AUTH_USER_FILE")
+    _auth_user_file_valid=true
+fi
+
+if [ -n "$PDF2ZH_AUTH_PASS_FILE" ] && [ -f "$PDF2ZH_AUTH_PASS_FILE" ]; then
+    _pass_lines=$(awk 'END {print NR}' "$PDF2ZH_AUTH_PASS_FILE")
+    _auth_pass_file_valid=true
+fi
+
+# Check if user and password file line counts are the same
+if [ "$_auth_user_file_valid" = true ] && [ "$_auth_pass_file_valid" = true ]; then
+    if [ "$_user_lines" -ne "$_pass_lines" ]; then
+        echo -e "\033[1;31mError: Line counts in user file=${PDF2ZH_AUTH_USER_FILE} and password=${PDF2ZH_AUTH_PASS_FILE} file do not match. Will not use auth file."
+    else
+        cat "$PDF2ZH_AUTH_USER_FILE" > "$_auth_user_file"
+        cat "$PDF2ZH_AUTH_PASS_FILE" > "$_auth_pass_file"
+        _auth_enabled=true
+    fi
+fi
+
+# Clean up sensitive environment variables
+unset PDF2ZH_AUTH_USER_FILE PDF2ZH_AUTH_PASS_FILE _user_lines _pass_lines
+
+# Add authorization arguments if auth is enabled
+if [ "$_auth_enabled" = true ]; then
+    chmod 600 "$_auth_user_file" "$_auth_pass_file" || { echo "Error: Failed to set permissions on auth files"; exit 1; }
+    echo -e "\033[1;33mWarning: --authorized flag doesn't work, so disable auth.\033[0m"
+    # _tmp_args="${_tmp_args} --authorized ${_auth_user_file} ${_auth_pass_file}"
+fi
+
+
+# handle debug mode
+if [ "$PDF2ZH_DEBUG" = "true" ]; then
+    _tmp_args="${_tmp_args} --debug"
+fi
 
 for i in ${!ENV_LIST[@]}; do
     ENV_NAME="${ENV_PREFIX}${ENV_LIST[$i]}"
@@ -18,10 +78,10 @@ for i in ${!ENV_LIST[@]}; do
 done
 
 # Welcome message
-echo "=================================================="
-echo " Welcome to PDF2ZH (PDFMathTranslate)!"
-echo " PDF scientific paper translation and bilingual comparison."
-echo " Project repository: https://github.com/Byaidu/PDFMathTranslate"
+echo "--------------------------------------------------"
+echo "Welcome to PDF2ZH (PDFMathTranslate)!"
+echo "PDF scientific paper translation and bilingual comparison."
+echo "Project repository: https://github.com/Byaidu/PDFMathTranslate"
 echo "--------------------------------------------------"
 
 # Get the current timestamp

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -54,14 +54,6 @@ fi
 # Clean up sensitive environment variables
 unset PDF2ZH_AUTH_USER_FILE PDF2ZH_AUTH_PASS_FILE _user_lines _pass_lines
 
-# Add authorization arguments if auth is enabled
-if [ "$_auth_enabled" = true ]; then
-    chmod 600 "$_auth_user_file" "$_auth_pass_file" || { echo "Error: Failed to set permissions on auth files"; exit 1; }
-    echo -e "\033[1;33mWarning: --authorized flag doesn't work, so disable auth.\033[0m"
-    # _tmp_args="${_tmp_args} --authorized ${_auth_user_file} ${_auth_pass_file}"
-fi
-
-
 # handle debug mode
 if [ "$PDF2ZH_DEBUG" = "true" ]; then
     _tmp_args="${_tmp_args} --debug"
@@ -89,11 +81,28 @@ start_time=$(date "+%Y-%m-%d %H:%M:%S")
 
 # Trim whitespace from _tmp_args
 _tmp_args=$(echo "${_tmp_args}" | xargs)
-# Define the command
+# Define the command which will be excuted
 cmd="pdf2zh --interactive ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
+cmd=$(echo $cmd | xargs)
+# Define the command to be printed, this is used to hide sensitive information
+_cmd_print=$cmd
+
+# Add authorization arguments if auth is enabled
+if [ "$_auth_enabled" = true ]; then
+    chmod 600 "$_auth_user_file" "$_auth_pass_file" || { echo "Error: Failed to set permissions on auth files"; exit 1; }
+    echo -e "\033[1;33mWarning: --authorized flag doesn't work, so disable auth. And Ignore the --authorized in the print message\033[0m"
+    # cmd="${cmd} --authorized ${_auth_user_file} ${_auth_pass_file}"
+    # Hide sensitive paths, only show filenames
+    _auth_user_file_name=$(basename "$_auth_user_file")
+    _auth_pass_file_name=$(basename "$_auth_pass_file")
+    # Update the printed command to hide full paths
+    _cmd_print="${_cmd_print} --authorized ****/${_auth_user_file_name} ****/${_auth_pass_file_name}"
+fi
+# Unset sensitive variables
+unset _auth_user_file _auth_pass_file
 
 # Print the command to be executed with the start time
-echo "[$start_time] Running: $cmd"
+echo "[$start_time] Running: $_cmd_print"
 echo "=================================================="
 
 # Execute the command

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -17,6 +17,24 @@ for i in ${!ENV_LIST[@]}; do
     _tmp_args="${_tmp_args} ${ENV_ARGS} ${ENV_VALUE}"
 done
 
-cmd="pdf2zh ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
-echo "Running: $cmd"
+# Welcome message
+echo "=================================================="
+echo " Welcome to PDF2ZH (PDFMathTranslate)!"
+echo " PDF scientific paper translation and bilingual comparison."
+echo " Project repository: https://github.com/Byaidu/PDFMathTranslate"
+echo "--------------------------------------------------"
+
+# Get the current timestamp
+start_time=$(date "+%Y-%m-%d %H:%M:%S")
+
+# Trim whitespace from _tmp_args
+_tmp_args=$(echo "${_tmp_args}" | xargs)
+# Define the command
+cmd="pdf2zh -i ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
+
+# Print the command to be executed with the start time
+echo "[$start_time] Running: $cmd"
+echo "=================================================="
+
+# Execute the command
 exec $cmd

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/env bash
+
+ENV_PREFIX="PDF2ZH_"
+ENV_LIST=(THREADS SOURCE_LANG TARGET_LANG AUTH_FILE)
+ENV_LIST_ARGS=(-p -li -lo --authorized)
+
+
+_tmp_args=""
+
+for i in ${!ENV_LIST[@]}; do
+    ENV_NAME="${ENV_PREFIX}${ENV_LIST[$i]}"
+    ENV_VALUE="${!ENV_NAME}"
+    if [ -z "$ENV_VALUE" ]; then
+        continue
+    fi
+    ENV_ARGS="${ENV_LIST_ARGS[$i]}"
+    _tmp_args="${_tmp_args} ${ENV_ARGS} ${ENV_VALUE}"
+done
+
+cmd="pdf2zh ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
+echo "Running: $cmd"
+exec $cmd

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -2,7 +2,7 @@
 
 ENV_PREFIX="PDF2ZH_"
 ENV_LIST=(THREADS SOURCE_LANG TARGET_LANG AUTH_FILE)
-ENV_LIST_ARGS=(-p -li -lo --authorized)
+ENV_LIST_ARGS=(-t -li -lo --authorized)
 
 
 _tmp_args=""

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -90,7 +90,7 @@ start_time=$(date "+%Y-%m-%d %H:%M:%S")
 # Trim whitespace from _tmp_args
 _tmp_args=$(echo "${_tmp_args}" | xargs)
 # Define the command
-cmd="pdf2zh -i ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
+cmd="pdf2zh --interactive ${_tmp_args} $PDF2ZH_OTHER_ARGS $@"
 
 # Print the command to be executed with the start time
 echo "[$start_time] Running: $cmd"


### PR DESCRIPTION
### Features

1. Add [entrypoint.sh](./script/entrypoint.sh) which will parse environment variables into arguments to start `pdf2zh`.

2. Supported environment variables:

    1. **General Settings**:
          1. `PDF2ZH_THREADS`: Number of threads to use.
          3. `PDF2ZH_SOURCE_LANG`: Source language for translation.
          4. `PDF2ZH_TARGET_LANG`: Target language for translation.
          5. `PDF2ZH_OTHER_ARGS`: Additional arguments for pdf2zh.
          6. `PDF2ZH_DEBUG`: Debug mode
          
   2. **Authentication Settings** (Currently not fully functional due to issues in pdf2zh argument parsing):
          1. `PDF2ZH_AUTH_USER`: The username for the authentication.
          2. `PDF2ZH_AUTH_PASS`: The password for the authentication.
          3. `PDF2ZH_AUTH_USER_FILE`: The path to the file containing the username for the authentication. Each line represents one username.
          4. `PDF2ZH_AUTH_PASS_FILE`: The path to the file containing the password for the authentication. The line count should match PDF2ZH_AUTH_USER_FILE.


7. Add [docker-compose.yml](./docker-compose.yml) as a basic example.

8. Add a welcome message:
```bash
pdf2zh  | ==================================================
pdf2zh  |  Welcome to PDF2ZH (PDFMathTranslate)!
pdf2zh  |  PDF scientific paper translation and bilingual comparison.
pdf2zh  |  Project repository: https://github.com/Byaidu/PDFMathTranslate
pdf2zh  | --------------------------------------------------
pdf2zh  | [2024-12-22 16:38:49] Running: pdf2zh -i -t 2 -li zh -lo en  
pdf2zh  | ==================================================
pdf2zh  | * Running on local URL:  http://0.0.0.0:7860
pdf2zh  | 
pdf2zh  | To create a public link, set `share=True` in `launch()`.
```