### PR TITLE
fix: Github action's output path

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -33,11 +33,11 @@ jobs:
 
     - name: Test - Translate a PDF file with plain text only
       run:
-        pdf2zh ./test/file/translate.cli.plain.text.pdf
+        pdf2zh ./test/file/translate.cli.plain.text.pdf -o ./test/file
 
     - name: Test - Translate a PDF file figure
       run:
-        pdf2zh ./test/file/translate.cli.text.with.figure.pdf
+        pdf2zh ./test/file/translate.cli.text.with.figure.pdf -o ./test/file
 
     # - name: Test - Translate a PDF file with unknown font
     #   run:


### PR DESCRIPTION
修复了未修改原有的输出目录导致下载不到文件的bug