### PR TITLE
Feature/add groq support

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -67,6 +67,7 @@ We've provided a detailed table on the required [environment variables](https://
 | **AnythingLLM**      | `anythingllm`  | `AnythingLLM_URL`, `AnythingLLM_APIKEY`                               | `[Your AnythingLLM URL]`, `[Your Key]`                   | See [anything-llm](https://github.com/Mintplex-Labs/anything-llm)                                                                                                                                         |
 |**Argos Translate**|`argos`| | |See [argos-translate](https://github.com/argosopentech/argos-translate)|
 |**Grok**|`grok`| `GORK_API_KEY`, `GORK_MODEL` | `[Your GORK_API_KEY]`, `grok-2-1212` |See [Grok](https://docs.x.ai/docs/overview)|
+|**Groq**|`groq`| `GROQ_API_KEY`, `GROQ_MODEL` | `[Your GROQ_API_KEY]`, `llama-3-3-70b-versatile` |See [Groq](https://console.groq.com/docs/models)|
 |**DeepSeek**|`deepseek`| `DEEPSEEK_API_KEY`, `DEEPSEEK_MODEL` | `[Your DEEPSEEK_API_KEY]`, `deepseek-chat` |See [DeepSeek](https://www.deepseek.com/)|
 |**OpenAI-Liked**|`openai-liked`| `OPENAILIKE_BASE_URL`, `OPENAILIKE_API_KEY`, `OPENAILIKE_MODEL` | `url`, `[Your Key]`, `model name` | None |
 

--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -37,6 +37,7 @@ from pdf2zh.translator import (
     XinferenceTranslator,
     ArgosTranslator,
     GorkTranslator,
+    GroqTranslator,
     DeepseekTranslator,
     OpenAIlikedTranslator,
 )
@@ -158,7 +159,7 @@ class TranslateConverter(PDFConverterEx):
         if not prompt:
             prompt = []
         for translator in [GoogleTranslator, BingTranslator, DeepLTranslator, DeepLXTranslator, OllamaTranslator, XinferenceTranslator, AzureOpenAITranslator,
-                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GorkTranslator, DeepseekTranslator, OpenAIlikedTranslator,]:
+                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GorkTranslator, GroqTranslator, DeepseekTranslator, OpenAIlikedTranslator,]:
             if service_name == translator.name:
                 self.translator = translator(lang_in, lang_out, service_model, envs=envs, prompt=prompt)
         if not self.translator:

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -34,6 +34,7 @@ from pdf2zh.translator import (
     XinferenceTranslator,
     ZhipuTranslator,
     GorkTranslator,
+    GroqTranslator,
     DeepseekTranslator,
     OpenAIlikedTranslator,
 )
@@ -58,6 +59,7 @@ service_map: dict[str, BaseTranslator] = {
     "AnythingLLM": AnythingLLMTranslator,
     "Argos Translate": ArgosTranslator,
     "Gork": GorkTranslator,
+    "Groq": GroqTranslator,
     "DeepSeek": DeepseekTranslator,
     "OpenAI-liked": OpenAIlikedTranslator,
 }

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -723,6 +723,24 @@ class GorkTranslator(OpenAITranslator):
         if prompt:
             self.add_cache_impact_parameters("prompt", prompt.template)
 
+class GroqTranslator(OpenAITranslator):
+    name = "groq"
+    envs = {
+        "GROQ_API_KEY": None,
+        "GROQ_MODEL": "llama-3-3-70b-versatile",
+    }
+    CustomPrompt = True
+
+    def __init__(self, lang_in, lang_out, model, envs=None, prompt=None):
+        self.set_envs(envs)
+        base_url = "https://api.groq.com/openai/v1"
+        api_key = self.envs["GROQ_API_KEY"]
+        if not model:
+            model = self.envs["GROQ_MODEL"]
+        super().__init__(lang_in, lang_out, model, base_url=base_url, api_key=api_key)
+        self.prompttext = prompt
+        if prompt:
+            self.add_cache_impact_parameters("prompt", prompt.template)
 
 class DeepseekTranslator(OpenAITranslator):
     name = "deepseek"


### PR DESCRIPTION
**Add Groq Translation Support**
Adds support for using Groq's LLaMA 3.3 70B model via their OpenAI-compatible API endpoint for text translation.
Changes

- Added GroqTranslator class inheriting from OpenAITranslator
- Added Groq to service map in GUI
- Added documentation for Groq environment variables

**Testing**

Set environment variable: GROQ_API_KEY=your_api_key
Test via CLI: pdf2zh example.pdf -s groq
Test via GUI: Select "Groq" from services dropdown

**Required Environment Variables**
CopyGROQ_API_KEY: Your Groq API key
GROQ_MODEL: llama-3-3-70b-versatile (default)

**Documentation**

Groq API docs: https://console.groq.com/docs
OpenAI compatibility: https://console.groq.com/docs/openai-migration

**Additional Context**

Uses Groq's OpenAI-compatible endpoint to maximize compatibility with existing code
Default model (LLaMA 3.3 70B) chosen for optimal balance of speed and translation quality
No code changes needed beyond adding the new translator class due to OpenAI API compatibility