### PR TITLE
change japanese lineheight

### DIFF
--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -377,7 +377,7 @@ class TranslateConverter(PDFConverterEx):
         # 根据目标语言获取默认行距
         LANG_LINEHEIGHT_MAP = {
             "zh-cn": 1.4, "zh-tw": 1.4, "zh-hans": 1.4, "zh-hant": 1.4, "zh": 1.4,
-            "ja": 1.1, "ko": 1.2, "en": 1.2, "ar": 1.0, "ru": 0.8, "uk": 0.8, "ta": 0.8
+            "ja": 1.4, "ko": 1.2, "en": 1.2, "ar": 1.0, "ru": 0.8, "uk": 0.8, "ta": 0.8
         }
         default_line_height = LANG_LINEHEIGHT_MAP.get(self.translator.lang_out.lower(), 1.1) # 小语种默认1.1
         _x, _y = 0, 0


### PR DESCRIPTION
When translated into Japanese, the layout tends to break (resulting in overlapping lines), so I think we should adjust the line height.

e.g.
![image](https://github.com/user-attachments/assets/e29c20cd-a510-4250-bb5d-856d0a7002d4)
