### PR TITLE
fix docker and ollama

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ADD "https://github.com/timelic/source-han-serif/releases/download/main/SourceHa
 ADD "https://github.com/timelic/source-han-serif/releases/download/main/SourceHanSerifKR-Regular.ttf" /app/
 
 RUN apt-get update && \
-     apt-get install --no-install-recommends -y libgl1 && \
+     apt-get install --no-install-recommends -y libgl1 libglib2.0-0 && \
      rm -rf /var/lib/apt/lists/* && uv pip install --system --no-cache huggingface-hub && \
      python3 -c "from huggingface_hub import hf_hub_download; hf_hub_download('wybxc/DocLayout-YOLO-DocStructBench-onnx','doclayout_yolo_docstructbench_imgsz1024.onnx');"
 

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -274,7 +274,7 @@ class OllamaTranslator(BaseTranslator):
             model = self.envs["OLLAMA_MODEL"]
         super().__init__(lang_in, lang_out, model)
         self.options = {"temperature": 0}  # 随机采样可能会打断公式标记
-        self.client = ollama.Client()
+        self.client = ollama.Client(host=self.envs["OLLAMA_HOST"])
         self.prompttext = prompt
         self.add_cache_impact_parameters("temperature", self.options["temperature"])
 


### PR DESCRIPTION
Fix 2 bugs:

1. The OLLAMA_HOST parameter passed by GUI is not set to ollama.Client. As a result, the code will request localhost even if the OLLAMA_HOST is specified by GUI or ENV.
2. Dockerfile will give out: #521  Error. 

I fixed those with minor revisions.

修俩小bug：

1. OLLAMA_HOST这个变量在GUI里以及环境变量里面指定了都没用，因为ollama.Client里面没有传进去
2. Dockerfile构建的docker存在依赖错误，dockerhub里面的docker也有这个问题，已经更新dockerfile