### PR TITLE
Minor Bug fix with ollama

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -280,7 +280,6 @@ class OllamaTranslator(BaseTranslator):
 
     def do_translate(self, text):
         maxlen = max(2000, len(text) * 5)
-        print("Prompt:", self.prompt(text, self.prompttext), "Maxlen:" , maxlen)
         for model in self.model.split(";"):
             try:
                 response = ""
@@ -307,7 +306,6 @@ class OllamaTranslator(BaseTranslator):
                     else:
                         response += chunk
                     if len(response) > maxlen:
-                        print(response)
                         raise Exception("Response too long")
                 return response.strip()
             except Exception as e:

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -290,7 +290,7 @@ class OllamaTranslator(BaseTranslator):
                     stream=True,
                 )
                 in_think_block = False
-                is_deepseek_r1 = model == "deepseek-r1"
+                is_deepseek_r1 = "deepseek-r1" in model
                 for chunk in stream:
                     chunk = chunk["message"]["content"]
                     # 只在 deepseek-r1 模型下检查 <think> 块


### PR DESCRIPTION
1. Improved the prompt to output the translated text only.
2. Removed the CoT output from r1 model.
3. 
Sort of mitigates #545  ,  #535 , but this “Response Too long” infinite loop is not solved and needs more work


1. 修改了一下prompt，让模型直接输出翻译后的文本
2. 把深度求索r1的思维链给过滤了。

算是缓解 #545 , #535 的问题，但是这个Response Too long的死循环的问题没有解决，需要更多的工作