### PR TITLE
fix(pdfinterp): Keep the color space effective after processing xobject.

### DIFF
--- a/pdf2zh/pdfinterp.py
+++ b/pdf2zh/pdfinterp.py
@@ -224,6 +224,8 @@ class PDFPageInterpreterEx(PDFPageInterpreter):
                 [xobj],
                 ctm=ctm,
             )
+            self.ncs = interpreter.ncs
+            self.scs = interpreter.scs
             try:  # 有的时候 form 字体加不上这里会烂掉
                 self.device.fontid = interpreter.fontid
                 self.device.fontmap = interpreter.fontmap


### PR DESCRIPTION
The issue in https://github.com/Byaidu/PDFMathTranslate/issues/588 can be fixed through this.

The following files are generated by pdf2zh.

[World.Economic.Outlook_IMF-40-mono.pdf](https://github.com/user-attachments/files/18725344/World.Economic.Outlook_IMF-40-mono.pdf)
[World.Economic.Outlook_IMF-40-dual.pdf](https://github.com/user-attachments/files/18725342/World.Economic.Outlook_IMF-40-dual.pdf)
