### PR TITLE
fix: :pencil2: Fix typo

### DIFF
--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -61,7 +61,7 @@ service_map: dict[str, BaseTranslator] = {
     "Dify": DifyTranslator,
     "AnythingLLM": AnythingLLMTranslator,
     "Argos Translate": ArgosTranslator,
-    "Gork": GorkTranslator,
+    "Grok": GorkTranslator,
     "Groq": GroqTranslator,
     "DeepSeek": DeepseekTranslator,
     "OpenAI-liked": OpenAIlikedTranslator,


### PR DESCRIPTION
Fix typo in service_map key for GorkTranslator

https://github.com/Byaidu/PDFMathTranslate/issues/598