### PR TITLE
fix: update API endpoint address in GoogleTranslator class

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -142,7 +142,7 @@ class GoogleTranslator(BaseTranslator):
     def __init__(self, lang_in, lang_out, model, **kwargs):
         super().__init__(lang_in, lang_out, model)
         self.session = requests.Session()
-        self.endpoint = "http://translate.google.com/m"
+        self.endpoint = "https://translate.google.com/m"
         self.headers = {
             "User-Agent": "Mozilla/4.0 (compatible;MSIE 6.0;Windows NT 5.1;SV1;.NET CLR 1.1.4322;.NET CLR 2.0.50727;.NET CLR 3.0.04506.30)"  # noqa: E501
         }


### PR DESCRIPTION
- 将 HTTP 端点地址改为 HTTPS，以提高数据传输的安全性
- 解决原来使用http协议google翻译请求次数多了之后报错的问题