### PR TITLE
[Fix] Fix hardcoded Azure OpenAI API version in translator

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -470,7 +470,7 @@ class AzureOpenAITranslator(BaseTranslator):
         "AZURE_OPENAI_BASE_URL": None,  # e.g. "https://xxx.openai.azure.com"
         "AZURE_OPENAI_API_KEY": None,
         "AZURE_OPENAI_MODEL": "gpt-4o-mini",
-        "AZURE_API_VERSION": "2024-06-01",  # default api version
+        "AZURE_OPENAI_API_VERSION": "2024-06-01",  # default api version
     }
     CustomPrompt = True
 
@@ -489,7 +489,7 @@ class AzureOpenAITranslator(BaseTranslator):
         base_url = self.envs["AZURE_OPENAI_BASE_URL"]
         if not model:
             model = self.envs["AZURE_OPENAI_MODEL"]
-        api_version = self.envs.get("AZURE_API_VERSION", "2024-06-01")
+        api_version = self.envs.get("AZURE_OPENAI_API_VERSION", "2024-06-01")
         if api_key is None:
             api_key = self.envs["AZURE_OPENAI_API_KEY"]
         super().__init__(lang_in, lang_out, model, ignore_cache)

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -470,6 +470,7 @@ class AzureOpenAITranslator(BaseTranslator):
         "AZURE_OPENAI_BASE_URL": None,  # e.g. "https://xxx.openai.azure.com"
         "AZURE_OPENAI_API_KEY": None,
         "AZURE_OPENAI_MODEL": "gpt-4o-mini",
+        "AZURE_API_VERSION": "2024-06-01",  # default api version
     }
     CustomPrompt = True
 
@@ -488,12 +489,15 @@ class AzureOpenAITranslator(BaseTranslator):
         base_url = self.envs["AZURE_OPENAI_BASE_URL"]
         if not model:
             model = self.envs["AZURE_OPENAI_MODEL"]
+        api_version = self.envs.get("AZURE_API_VERSION", "2024-06-01")
+        if api_key is None:
+            api_key = self.envs["AZURE_OPENAI_API_KEY"]
         super().__init__(lang_in, lang_out, model, ignore_cache)
         self.options = {"temperature": 0}
         self.client = openai.AzureOpenAI(
             azure_endpoint=base_url,
             azure_deployment=model,
-            api_version="2024-06-01",
+            api_version=api_version,
             api_key=api_key,
         )
         self.prompttext = prompt


### PR DESCRIPTION
I encountered an authentication error while testing my Azure OpenAI API key.  
After debugging, I found that the `api_version` was hardcoded instead of using the configured environment variable.  
This caused 401 errors like the following:

```
[04/27/25 15:50:37] ERROR ERROR:pdf2zh.converter:Error code: 401 - {'error': {'code': '401', 'message': 'Access denied due to invalid subscription key or wrong API endpoint. Make sure to provide a valid key for an active subscription and use a correct regional API endpoint for your resource.'}}
```

This PR fixes it by properly using the `AZURE_OPENAI_API_VERSION` from the environment settings.
