### PR TITLE
Fix Docker Hub URL in README.md badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ English | [简体中文](docs/README_zh-CN.md) | [繁體中文](docs/README_zh-T
     <img src="https://img.shields.io/pypi/v/pdf2zh"></a>
   <a href="https://pepy.tech/projects/pdf2zh">
     <img src="https://static.pepy.tech/badge/pdf2zh"></a>
-  <a href="https://hub.docker.com/repository/docker/byaidu/pdf2zh">
+  <a href="https://hub.docker.com/r/byaidu/pdf2zh">
     <img src="https://img.shields.io/docker/pulls/byaidu/pdf2zh"></a>
   <a href="https://hellogithub.com/repository/8ec2cfd3ef744762bf531232fa32bc47" target="_blank"><img src="https://api.hellogithub.com/v1/widgets/recommend.svg?rid=8ec2cfd3ef744762bf531232fa32bc47&claim_uid=JQ0yfeBNjaTuqDU&theme=small" alt="Featured｜HelloGitHub" /></a>
   <a href="https://gitcode.com/Byaidu/PDFMathTranslate/overview">


### PR DESCRIPTION
PR Summary from GitHub Copilot:

> This pull request includes a minor update to the `README.md` file. The change updates the Docker Hub repository link to use the correct URL format.
> 
> * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L15-R15): Updated the Docker Hub repository link from `https://hub.docker.com/repository/docker/byaidu/pdf2zh` to `https://hub.docker.com/r/byaidu/pdf2zh` for accuracy.