### PR TITLE
Fix AttributeError in PDFPageInterpreterEx by using graphicstate.ncs/scs

### DIFF
--- a/pdf2zh/pdfinterp.py
+++ b/pdf2zh/pdfinterp.py
@@ -163,8 +163,8 @@ class PDFPageInterpreterEx(PDFPageInterpreter):
     # 重载返回调用参数（SCN）
     def do_SCN(self) -> None:
         """Set color for stroking operations."""
-        if self.scs:
-            n = self.scs.ncomponents
+        if self.graphicstate.scs:
+            n = self.graphicstate.scs.ncomponents
         else:
             if settings.STRICT:
                 raise PDFInterpreterError("No colorspace specified!")
@@ -175,8 +175,8 @@ class PDFPageInterpreterEx(PDFPageInterpreter):
 
     def do_scn(self) -> None:
         """Set color for nonstroking operations"""
-        if self.ncs:
-            n = self.ncs.ncomponents
+        if self.graphicstate.ncs:
+            n = self.graphicstate.ncs.ncomponents
         else:
             if settings.STRICT:
                 raise PDFInterpreterError("No colorspace specified!")
@@ -224,8 +224,8 @@ class PDFPageInterpreterEx(PDFPageInterpreter):
                 [xobj],
                 ctm=ctm,
             )
-            self.ncs = interpreter.ncs
-            self.scs = interpreter.scs
+            self.graphicstate.ncs = interpreter.graphicstate.ncs
+            self.graphicstate.scs = interpreter.graphicstate.scs
             try:  # 有的时候 form 字体加不上这里会烂掉
                 self.device.fontid = interpreter.fontid
                 self.device.fontmap = interpreter.fontmap


### PR DESCRIPTION
## Summary

This PR resolves a runtime error when using `pdf2zh` on certain PDF files, specifically related to incorrect access of `ncs` and `scs` attributes within the `PDFPageInterpreterEx` class.

When running the following command on macOS with Python 3.9 and LibreSSL:

```bash
pdf2zh "[Reading] Exploring the spillover effects of WeChat using graphical model.pdf" -li en -lo ko -s ollama
```

The following error is raised:

```
Traceback (most recent call last):
  File ".../pdf2zh", line 8, in <module>
    sys.exit(main())
  File ".../pdf2zh.py", line 264, in main
    translate(model=ModelInstance.value, **vars(parsed_args))
  File ".../high_level.py", line 355, in translate
    s_mono, s_dual = translate_stream(
  File ".../high_level.py", line 215, in translate_stream
    obj_patch: dict = translate_patch(fp, **locals())
  File ".../high_level.py", line 156, in translate_patch
    interpreter.process_page(page)
  File ".../pdfinterp.py", line 269, in process_page
    ops_base = self.render_contents(page.resources, page.contents, ctm=ctm)
  File ".../pdfinterp.py", line 299, in render_contents
    return self.execute(list_value(streams))
  File ".../pdfinterp.py", line 345, in execute
    targs = func()
  File ".../pdfinterp.py", line 178, in do_scn
    if self.ncs:
AttributeError: 'PDFPageInterpreterEx' object has no attribute 'ncs'
```

### Cause

The `ncs` (non-stroking color space) and `scs` (stroking color space) attributes are not defined directly on `PDFPageInterpreterEx` but are part of the internal `graphicstate` object. This structure is consistent with the original `pdfminer.six` design. However, `pdf2zh` incorrectly uses `self.ncs` and `self.scs`, resulting in an `AttributeError`.

### Fix

- All references to `self.ncs` and `self.scs` are replaced with `self.graphicstate.ncs` and `self.graphicstate.scs`
- Incorrect assignments like `self.ncs = interpreter.ncs` in `do_Do` are updated to `self.graphicstate.ncs = interpreter.graphicstate.ncs`

### Result

After this fix, `pdf2zh` runs successfully and processes all pages without error:

```bash
100%|████████████████████████████████████████████████████████████████████████████| 21/21 [00:06<00:00,  3.21it/s]
```

### Environment

- macOS (Apple Silicon)
- Python 3.9
- pdf2zh installed via `uv`
- LibreSSL 2.8.3 (a non-blocking warning from urllib3 appears, unrelated to this PR)

### Notes

- This is a bugfix-only change with no effect on output or behavior
- Fix aligns with upstream `pdfminer.six`'s handling of color state (SCN, scn) logic