### PR TITLE
fix handling of prompt in OpenAI liked Translator

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -998,8 +998,8 @@ class OpenAIlikedTranslator(OpenAITranslator):
             base_url=base_url,
             api_key=api_key,
             ignore_cache=ignore_cache,
+            prompt=prompt,
         )
-        self.prompttext = prompt
 
 
 class QwenMtTranslator(OpenAITranslator):


### PR DESCRIPTION
The `self.prompttext = prompt` operation is already handled by OpenAITranslator. To avoid redundant processing, I've modified OpenAILikedTranslator to include the prompt in the `super().__init__` call.