### PR TITLE
Fix handling of prompts in HTTP API

### DIFF
--- a/pdf2zh/backend.py
+++ b/pdf2zh/backend.py
@@ -5,6 +5,7 @@ from pdf2zh import translate_stream
 import tqdm
 import json
 import io
+from string import Template
 from pdf2zh.doclayout import ModelInstance
 from pdf2zh.config import ConfigManager
 
@@ -44,6 +45,9 @@ def translate_task(
     def progress_bar(t: tqdm.tqdm):
         self.update_state(state="PROGRESS", meta={"n": t.n, "total": t.total})  # noqa
         print(f"Translating {t.n} / {t.total} pages")
+
+    if "prompt" in args:
+        args["prompt"] = Template(args["prompt"])
 
     doc_mono, doc_dual = translate_stream(
         stream,


### PR DESCRIPTION
In previous versions of the HTTP API, arguments containing prompts were simply passed through without special processing. As a result, when prompts were included in the HTTP API request, the string would be directly passed to the `translate_stream` function. To prevent this, I now convert any `prompt` values found in `args` into templates.
