### PR TITLE
 Fix OpenAI-compatible translators by omitting empty stop/max_tokens   params

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -439,17 +439,19 @@ class OpenAITranslator(BaseTranslator):
         )
         self.options = {
             "temperature": 0,  # 随机采样可能会打断公式标记
-            "stop": stop_tokens,
-            "max_tokens": max_tokens if max_tokens > 0 else None,
         }
+        if stop_tokens:
+            self.options["stop"] = stop_tokens
+        if max_tokens > 0:
+            self.options["max_tokens"] = max_tokens
         self.client = openai.OpenAI(
             base_url=base_url or self.envs["OPENAI_BASE_URL"],
             api_key=api_key or self.envs["OPENAI_API_KEY"],
         )
         self.prompttext = prompt
         self.add_cache_impact_parameters("temperature", self.options["temperature"])
-        self.add_cache_impact_parameters("stop", self.options["stop"])
-        self.add_cache_impact_parameters("max_tokens", self.options["max_tokens"])
+        self.add_cache_impact_parameters("stop", self.options.get("stop"))
+        self.add_cache_impact_parameters("max_tokens", self.options.get("max_tokens"))
         self.add_cache_impact_parameters("prompt", self.prompt("", self.prompttext))
         think_filter_regex = r"^<think>.+?\n*(</think>|\n)*(</think>)\n*"
         self.add_cache_impact_parameters("think_filter_regex", think_filter_regex)


### PR DESCRIPTION
## Problem and Reproduction

  Gemini requests sent through the shared OpenAITranslator path included empty optional params:
  - stop: []
  - max_tokens: null

  This caused Gemini's OpenAI-compatible endpoint to reject requests with:
```
Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/app/pdf2zh/translator.py", line 100, in translate
      translation = self.do_translate(text)
                    ^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py",
  line 331, in wrapped_f
      return copy(f, *args, **kw)
             ^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py",
  line 470, in __call__
      do = self.iter(retry_state=retry_state)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py",
  line 371, in iter
      result = action(retry_state)
               ^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py",
  line 393, in <lambda>
      self._add_action_func(lambda rs: rs.outcome.result())
                                       ^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line
  449, in result
      return self.__get_result()
             ^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/concurrent/futures/_base.py", line
  401, in __get_result
      raise self._exception
    File "/usr/local/lib/python3.12/site-packages/tenacity/__init__.py",
  line 473, in __call__
      result = fn(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^
    File "/app/pdf2zh/translator.py", line 471, in do_translate
      response = self.client.chat.completions.create(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/openai/_utils/
  _utils.py", line 286, in wrapper
      return func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/openai/resources/chat/
  completions/completions.py", line 1211, in create
      return self._post(
             ^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/openai/
  _base_client.py", line 1297, in post
      return cast(ResponseT, self.request(cast_to, opts, stream=stream,
  stream_cls=stream_cls))

  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/local/lib/python3.12/site-packages/openai/
  _base_client.py", line 1070, in request
      raise self._make_status_error_from_response(err.response) from None
  openai.BadRequestError: Error code: 400 - [{'error': {'code': 400,
  'message': 'Value is not a string: []', 'status': 'INVALID_ARGUMENT'}}]
```
  
  Reproduction:
```python 
  from pdf2zh.translator import GeminiTranslator

  t = GeminiTranslator("en", "zh", None, ignore_cache=True)
  print(t.translate("Hello world"))
```


  ## Changes
  - Omit stop unless stop_tokens is non-empty
  - Omit max_tokens unless it is explicitly positive
  - Use .get(...) when recording optional cache-impact params to avoid
    KeyError


  ## Reference

  - OpenAI Chat Completions API:  https://platform.openai.com/docs/api-reference/chat/create-chat-completion
  - Gemini OpenAI compatibility API:  https://ai.google.dev/gemini-api/docs/openai
  - Related Gemini compatibility discussion:  https://discuss.ai.google.dev/t/openai-compatibility-api-does-not-support-message-refusal-field-set-to-null/100010