### PR TITLE
fix(qwen-mt): support zh-CN and region-qualified language codes in lang_mapping

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1161,11 +1161,11 @@ class QwenMtTranslator(OpenAITranslator):
     def lang_mapping(input_lang: str) -> str:
         """
         Mapping the language code to the language code that Aliyun Qwen-Mt model supports.
-        Since all existings languagues codes used in gui.py are able to be mapped, the original
-        languague code will not be checked.
+        Supports both short codes (e.g. "zh") and region-qualified codes (e.g. "zh-CN").
         """
         langdict = {
             "zh": "Chinese",
+            "zh-CN": "Chinese",
             "zh-TW": "Chinese",
             "en": "English",
             "fr": "French",
@@ -1177,7 +1177,16 @@ class QwenMtTranslator(OpenAITranslator):
             "it": "Italian",
         }
 
-        return langdict[input_lang]
+        if input_lang in langdict:
+            return langdict[input_lang]
+        # Fall back to prefix match (e.g. "zh-SG" -> "zh" -> "Chinese")
+        prefix = input_lang.split("-")[0]
+        if prefix in langdict:
+            return langdict[prefix]
+        raise KeyError(
+            f"Unsupported language code for Qwen-MT: '{input_lang}'. "
+            f"Supported codes: {list(langdict.keys())}"
+        )
 
     def do_translate(self, text) -> str:
         """


### PR DESCRIPTION
Fixes #951

## Problem

`QwenMtTranslator.lang_mapping()` raised `KeyError: 'zh-CN'` when users passed region-qualified language codes like `zh-CN` via the CLI:

```bash
pdf2zh paper.pdf -s qwen-mt -lo zh-CN
```

The root cause is that `langdict` only contained `"zh"` as the Simplified Chinese key. When `BaseTranslator.__init__` does not normalise the code (since `QwenMtTranslator` has no `lang_map` class variable), `self.lang_out` becomes `"zh-CN"`, and the strict `langdict[input_lang]` lookup fails.

## Solution

1. **Add `"zh-CN"` explicitly** to `langdict` so the most common Simplified Chinese code is recognised directly.
2. **Add a prefix-based fallback**: if an exact match is not found, try matching on the BCP-47 primary subtag (e.g. `"zh-SG"` → `"zh"` → `"Chinese"`). This future-proofs the method against other region variants without requiring exhaustive enumeration.
3. **Replace the bare `KeyError`** with an informative message that lists supported codes, making debugging easier for users who pass unsupported languages.

## Testing

Verified by unit-level inspection that:
- `lang_mapping("zh-CN")` now returns `"Chinese"`
- `lang_mapping("zh")` still returns `"Chinese"`
- `lang_mapping("zh-TW")` still returns `"Chinese"`
- `lang_mapping("en-US")` returns `"English"` via the prefix fallback
- `lang_mapping("xx")` raises a `KeyError` with a helpful message