### PR TITLE
Enable local Codex translation without API keys

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -77,6 +77,7 @@ We've provided a detailed table on the required [environment variables](https://
 |**MiniMax**|`minimax`| `MINIMAX_API_KEY`, `MINIMAX_MODEL` | `[Your MINIMAX_API_KEY]`, `MiniMax-M2.7` |See [MiniMax](https://platform.minimaxi.com/)|
 |**OpenAI-Liked**|`openailiked`| `OPENAILIKED_BASE_URL`, `OPENAILIKED_API_KEY`, `OPENAILIKED_MODEL` | `url`, `[Your Key]`, `model name` | None |
 |**OpenAI-Liked**|`openailiked`| `OPENAILIKED_BASE_URL`, `OPENAILIKED_API_KEY`, `OPENAILIKED_MODEL`, `OPENAILIKED_STOP_TOKENS`, `OPENAILIKED_MAX_TOKENS` | `url`, `[Your Key]`, `model name`, ` `, `-1` | None |
+|**Codex**|`codex`| `CODEX_BIN`, `CODEX_PROFILE`, `CODEX_MODEL`, `CODEX_TIMEOUT` | `codex`, ``, `gpt-5.4-mini`, `120` | Uses the local Codex CLI login state. No API key required. By default it prefers a lightweight non-interactive path with reasoning effort forced to `none`, and effective concurrency is currently fixed to `1`. |
 |**Ali Qwen Translation**|`qwen-mt`| `ALI_MODEL`, `ALI_API_KEY`, `ALI_DOMAINS` | `qwen-mt-turbo`, `[Your Key]`, `scientific paper` | Tranditional Chinese are not yet supported, it will be translated into Simplified Chinese. More see [Qwen MT](https://bailian.console.aliyun.com/?spm=5176.28197581.0.0.72e329a4HRxe99#/model-market/detail/qwen-mt-turbo) |
 
 For large language models that are compatible with the OpenAI API but not listed in the table above, you can set environment variables using the same method outlined for OpenAI in the table.

--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -13,7 +13,7 @@ from pdfminer.pdffont import PDFCIDFont, PDFUnicodeNotDefined
 from pdfminer.pdfinterp import PDFGraphicState, PDFResourceManager
 from pdfminer.utils import apply_matrix_pt, mult_matrix
 from pymupdf import Font
-from tenacity import retry, wait_fixed
+from tenacity import retry, wait_fixed, stop_after_attempt
 
 from pdf2zh.translator import (
     AnythingLLMTranslator,
@@ -22,6 +22,7 @@ from pdf2zh.translator import (
     AzureTranslator,
     BaseTranslator,
     BingTranslator,
+    CodexTranslator,
     DeepLTranslator,
     DeepLXTranslator,
     DeepseekTranslator,
@@ -161,11 +162,65 @@ class TranslateConverter(PDFConverterEx):
         if not envs:
             envs = {}
         for translator in [GoogleTranslator, BingTranslator, DeepLTranslator, DeepLXTranslator, OllamaTranslator, XinferenceTranslator, AzureOpenAITranslator,
-                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, QwenMtTranslator, X302AITranslator]:
+                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, CodexTranslator, QwenMtTranslator, X302AITranslator]:
             if service_name == translator.name:
                 self.translator = translator(lang_in, lang_out, service_model, envs=envs, prompt=prompt, ignore_cache=ignore_cache)
         if not self.translator:
             raise ValueError("Unsupported translation service")
+
+    @staticmethod
+    def _is_passthrough_text(s: str) -> bool:
+        return not s.strip() or re.match(r"^\{v\d+\}$", s)
+
+    def _translate_text_segments(self, sstk: list[str]) -> list[str]:
+        @retry(wait=wait_fixed(1))
+        def worker(s: str):
+            if self._is_passthrough_text(s):
+                return s
+            try:
+                return self.translator.translate(s)
+            except BaseException as e:
+                if log.isEnabledFor(logging.DEBUG):
+                    log.exception(e)
+                else:
+                    log.exception(e, exc_info=False)
+                raise e
+
+        @retry(wait=wait_fixed(1), stop=stop_after_attempt(3))
+        def batch_worker(texts: list[str]):
+            try:
+                return self.translator.translate_batch(texts)
+            except BaseException as e:
+                if log.isEnabledFor(logging.DEBUG):
+                    log.exception(e)
+                else:
+                    log.exception(e, exc_info=False)
+                raise e
+
+        if getattr(self.translator, "name", "") == "codex":
+            if self.thread and self.thread > 1:
+                log.warning(
+                    "Codex translator currently forces effective concurrency to 1; requested thread=%s is ignored.",
+                    self.thread,
+                )
+            results = list(sstk)
+            translatable_indices = []
+            translatable_texts = []
+            for idx, text in enumerate(sstk):
+                if self._is_passthrough_text(text):
+                    continue
+                translatable_indices.append(idx)
+                translatable_texts.append(text)
+            if translatable_texts:
+                translated_batch = batch_worker(translatable_texts)
+                for idx, translated in zip(translatable_indices, translated_batch):
+                    results[idx] = translated
+            return results
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=self.thread
+        ) as executor:
+            return list(executor.map(worker, sstk))
 
     def receive_layout(self, ltpage: LTPage):
         # 段落
@@ -344,24 +399,7 @@ class TranslateConverter(PDFConverterEx):
         ############################################################
         # B. 段落翻译
         log.debug("\n==========[SSTACK]==========\n")
-
-        @retry(wait=wait_fixed(1))
-        def worker(s: str):  # 多线程翻译
-            if not s.strip() or re.match(r"^\{v\d+\}$", s):  # 空白和公式不翻译
-                return s
-            try:
-                new = self.translator.translate(s)
-                return new
-            except BaseException as e:
-                if log.isEnabledFor(logging.DEBUG):
-                    log.exception(e)
-                else:
-                    log.exception(e, exc_info=False)
-                raise e
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.thread
-        ) as executor:
-            news = list(executor.map(worker, sstk))
+        news = self._translate_text_segments(sstk)
 
         ############################################################
         # C. 新文档排版

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -25,6 +25,7 @@ from pdf2zh.translator import (
     AzureTranslator,
     BaseTranslator,
     BingTranslator,
+    CodexTranslator,
     DeepLTranslator,
     DeepLXTranslator,
     DifyTranslator,
@@ -94,6 +95,7 @@ service_map: dict[str, BaseTranslator] = {
     "DeepSeek": DeepseekTranslator,
     "MiniMax": MiniMaxTranslator,
     "OpenAI-liked": OpenAIlikedTranslator,
+    "Codex": CodexTranslator,
     "Ali Qwen-Translation": QwenMtTranslator,
     "302.AI": X302AITranslator,
 }
@@ -332,6 +334,12 @@ def translate_file(
         threads = int(threads)
     except ValueError:
         threads = 1
+    if translator.name == "codex" and threads != 1:
+        gr.Info(
+            "Codex currently runs with effective concurrency fixed to 1. "
+            "The requested thread count will be ignored."
+        )
+        threads = 1
 
     param = {
         "files": [str(file_raw)],
@@ -425,6 +433,7 @@ def babeldoc_translate_file(**kwargs):
         GroqTranslator,
         DeepseekTranslator,
         OpenAIlikedTranslator,
+        CodexTranslator,
         QwenMtTranslator,
         X302AITranslator,
     ]:
@@ -459,7 +468,9 @@ def babeldoc_translate_file(**kwargs):
             no_mono=False,
             qps=kwargs["thread"],
             use_rich_pbar=False,
-            disable_rich_text_translate=not isinstance(translator, OpenAITranslator),
+            disable_rich_text_translate=not isinstance(
+                translator, (OpenAITranslator, CodexTranslator)
+            ),
             skip_clean=kwargs["skip_subset_fonts"],
             report_interval=0.5,
         )

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -417,6 +417,7 @@ def yadt_main(parsed_args) -> int:
         AzureOpenAITranslator,
         GoogleTranslator,
         BingTranslator,
+        CodexTranslator,
         DeepLTranslator,
         DeepLXTranslator,
         OllamaTranslator,
@@ -461,6 +462,7 @@ def yadt_main(parsed_args) -> int:
         GroqTranslator,
         DeepseekTranslator,
         OpenAIlikedTranslator,
+        CodexTranslator,
         QwenMtTranslator,
         X302AITranslator,
     ]:

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import re
+import subprocess
+import tempfile
 import unicodedata
 from copy import copy
 from string import Template
@@ -100,6 +102,11 @@ class BaseTranslator:
         translation = self.do_translate(text)
         self.cache.set(text, translation)
         return translation
+
+    def translate_batch(
+        self, texts: list[str], ignore_cache: bool = False
+    ) -> list[str]:
+        return [self.translate(text, ignore_cache=ignore_cache) for text in texts]
 
     def do_translate(self, text: str) -> str:
         """
@@ -1120,6 +1127,519 @@ class OpenAIlikedTranslator(OpenAITranslator):
             content = response.choices[0].message.content.strip()
         content = self.think_filter_regex.sub("", content).strip()
         return content
+
+
+class CodexTranslator(BaseTranslator):
+    name = "codex"
+    envs = {
+        "CODEX_BIN": "codex",
+        "CODEX_PROFILE": None,
+        "CODEX_MODEL": "gpt-5.4-mini",
+        "CODEX_TIMEOUT": "120",
+    }
+    CustomPrompt = True
+    REQUIRED_EXEC_FLAGS = {
+        "--skip-git-repo-check",
+        "--ephemeral",
+        "--sandbox",
+        "--color",
+        "--output-schema",
+        "--output-last-message",
+    }
+    FAST_PATH_FLAGS = {"--ignore-user-config", "--ignore-rules", "--model", "-c"}
+    COMPAT_PATH_FLAGS = {"--model", "--profile"}
+    MAX_BATCH_ITEMS = 8
+    MAX_BATCH_CHARS = 2500
+    MAX_ITEM_CHARS = 300
+    HSPACE_RE = r"[ \t\u00A0]+"
+    CJK_CHAR_RE = r"[\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff]"
+    CJK_PUNCT_RE = r"[\u3001-\u303f\uff01-\uff0f\uff1a-\uff20\uff3b-\uff40\uff5b-\uff65]"
+    PLACEHOLDER_RE = r"(?:\{\{v\d+\}\}|\{v\d+\})"
+
+    def __init__(
+        self, lang_in, lang_out, model, envs=None, prompt=None, ignore_cache=False
+    ):
+        self.set_envs(envs)
+        if not model:
+            model = self.envs["CODEX_MODEL"]
+        super().__init__(lang_in, lang_out, model, ignore_cache)
+        self.codex_bin = self.envs["CODEX_BIN"] or "codex"
+        self.profile = self.envs["CODEX_PROFILE"]
+        self.timeout = int(self.envs.get("CODEX_TIMEOUT") or "120")
+        self.prompttext = prompt
+        self.single_output_schema = {
+            "type": "object",
+            "properties": {
+                "translation": {"type": "string"},
+            },
+            "required": ["translation"],
+            "additionalProperties": False,
+        }
+        self.batch_output_schema = {
+            "type": "object",
+            "properties": {
+                "translations": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                }
+            },
+            "required": ["translations"],
+            "additionalProperties": False,
+        }
+        self.codex_version = None
+        self.supported_exec_flags: set[str] = set()
+        self.fast_command_available = False
+        self.compat_command_available = False
+        self.preferred_command_mode = "fast"
+        self._probe_cli()
+        self.add_cache_impact_parameters("profile", self.profile)
+        self.add_cache_impact_parameters("prompt", self.prompt("", self.prompttext))
+        self.add_cache_impact_parameters("command_mode", self.preferred_command_mode)
+
+    def _build_codex_prompt(self, text: str) -> str:
+        base_prompt = self.prompt(text, self.prompttext)[0]["content"]
+        return (
+            f"{base_prompt}\n\n"
+            "Additional requirements:\n"
+            '- Return valid JSON with exactly one field: {"translation": "..."}.\n'
+            '- The "translation" field must contain only the translated text.\n'
+            "- Preserve markdown structure and formulas.\n"
+            "- Preserve placeholder tokens like {v0} and {{v0}} exactly.\n"
+            "- Do not add explanations, comments, or code fences.\n"
+        )
+
+    def _build_batch_prompt(self, texts: list[str]) -> str:
+        indexed_texts = [
+            {"index": idx, "text": text} for idx, text in enumerate(texts, start=1)
+        ]
+        serialized_texts = json.dumps(indexed_texts, ensure_ascii=False)
+        return (
+            "You are a professional, authentic machine translation engine. "
+            "Only output valid JSON that matches the provided schema.\n\n"
+            f"Translate the `text` field of each object in the following JSON array "
+            f"from {self.lang_in} to {self.lang_out}. Preserve markdown structure, "
+            "formulas, and placeholder tokens like {v0} and {{v0}} exactly. "
+            f"There are exactly {len(texts)} items. Return exactly {len(texts)} "
+            "translated strings in ascending `index` order. Do not merge, drop, "
+            "or reorder items.\n\n"
+            f"Source Texts JSON: {serialized_texts}\n\n"
+            'Return JSON with exactly one field: {"translations": ["...", "..."]}.'
+        )
+
+    def _run_probe_command(self, args: list[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                [self.codex_bin, *args],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"codex executable not found: {self.codex_bin}"
+            ) from exc
+
+    def _probe_cli(self):
+        version_result = self._run_probe_command(["--version"])
+        if version_result.returncode != 0:
+            detail = version_result.stderr.strip() or version_result.stdout.strip()
+            raise RuntimeError(f"Codex CLI version probe failed: {detail}")
+        self.codex_version = version_result.stdout.strip() or version_result.stderr.strip()
+
+        help_result = self._run_probe_command(["exec", "--help"])
+        if help_result.returncode != 0:
+            detail = help_result.stderr.strip() or help_result.stdout.strip()
+            raise RuntimeError(f"Codex CLI help probe failed: {detail}")
+
+        help_text = "\n".join([help_result.stdout, help_result.stderr])
+        candidate_flags = (
+            self.REQUIRED_EXEC_FLAGS
+            | self.FAST_PATH_FLAGS
+            | self.COMPAT_PATH_FLAGS
+            | {"--config"}
+        )
+        self.supported_exec_flags = {
+            flag for flag in candidate_flags if flag in help_text
+        }
+        if "--config" in self.supported_exec_flags:
+            self.supported_exec_flags.add("-c")
+
+        missing_required = self.REQUIRED_EXEC_FLAGS - self.supported_exec_flags
+        if missing_required:
+            raise RuntimeError(
+                "Codex CLI is missing required exec flags: "
+                + ", ".join(sorted(missing_required))
+            )
+
+        self.compat_command_available = True
+        self.fast_command_available = self.FAST_PATH_FLAGS.issubset(
+            self.supported_exec_flags
+        ) and not self.profile
+        if self.profile:
+            if "--profile" not in self.supported_exec_flags:
+                raise RuntimeError(
+                    "Codex CLI does not support --profile, but CODEX_PROFILE was set."
+                )
+            self.preferred_command_mode = "compat"
+        elif self.fast_command_available:
+            self.preferred_command_mode = "fast"
+        else:
+            self.preferred_command_mode = "compat"
+
+    @staticmethod
+    def _is_passthrough_text(text: str) -> bool:
+        return not text.strip() or re.match(r"^\{v\d+\}$", text) is not None
+
+    @staticmethod
+    def _looks_like_unsupported_flag(detail: str) -> bool:
+        lowered = detail.lower()
+        return any(
+            needle in lowered
+            for needle in [
+                "unexpected argument",
+                "unrecognized option",
+                "unknown option",
+                "found argument",
+            ]
+        )
+
+    def _build_command(
+        self, prompt_text: str, schema_path: str, output_path: str, mode: str
+    ) -> list[str]:
+        command = [
+            self.codex_bin,
+            "exec",
+        ]
+        if mode == "fast":
+            command.extend(["--ignore-user-config", "--ignore-rules"])
+        if mode == "compat" and self.profile:
+            command.extend(["--profile", self.profile])
+        command.extend(
+            [
+                "--skip-git-repo-check",
+                "--ephemeral",
+                "--sandbox",
+                "read-only",
+                "--color",
+                "never",
+            ]
+        )
+        if self.model and "--model" in self.supported_exec_flags:
+            command.extend(["--model", self.model])
+        if mode == "fast" and "-c" in self.supported_exec_flags:
+            command.extend(["-c", 'model_reasoning_effort="none"'])
+        command.extend(
+            [
+                "--output-schema",
+                schema_path,
+                "--output-last-message",
+                output_path,
+            ]
+        )
+        command.append(prompt_text)
+        return command
+
+    def _load_json_output(self, output_path: str) -> dict:
+        if not os.path.exists(output_path):
+            raise RuntimeError("Codex translator did not produce an output file.")
+        try:
+            with open(output_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Codex translator returned invalid JSON output.") from exc
+
+    def _load_translation(self, output_path: str) -> str:
+        payload = self._load_json_output(output_path)
+        translation = payload.get("translation")
+        if not isinstance(translation, str) or not translation.strip():
+            raise RuntimeError(
+                "Codex translator output is missing the required 'translation' field."
+            )
+        return self._normalize_translation_output(translation.strip())
+
+    def _load_batch_translations(self, output_path: str, expected_count: int) -> list[str]:
+        payload = self._load_json_output(output_path)
+        translations = payload.get("translations")
+        if not isinstance(translations, list):
+            raise RuntimeError(
+                "Codex translator output is missing the required 'translations' field."
+            )
+        if len(translations) != expected_count:
+            raise RuntimeError(
+                "Codex translator batch output must have the same length as the input."
+            )
+        if any(not isinstance(item, str) or not item.strip() for item in translations):
+            raise RuntimeError("Codex translator batch output contains empty items.")
+        return [self._normalize_translation_output(item.strip()) for item in translations]
+
+    def _iter_command_modes(self) -> list[str]:
+        if self.preferred_command_mode == "compat" or not self.fast_command_available:
+            return ["compat"]
+        return ["fast", "compat"]
+
+    def _execute_codex_request(
+        self, prompt_text: str, schema: dict, response_loader, mode_override: str = None
+    ):
+        with tempfile.TemporaryDirectory(prefix="pdf2zh-codex-") as workdir:
+            schema_path = os.path.join(workdir, "output.schema.json")
+            output_path = os.path.join(workdir, "output.json")
+            with open(schema_path, "w", encoding="utf-8") as f:
+                json.dump(schema, f)
+
+            modes = [mode_override] if mode_override else self._iter_command_modes()
+            last_error = None
+            for mode in modes:
+                command = self._build_command(prompt_text, schema_path, output_path, mode)
+                try:
+                    result = subprocess.run(
+                        command,
+                        cwd=workdir,
+                        stdin=subprocess.DEVNULL,
+                        capture_output=True,
+                        text=True,
+                        timeout=self.timeout,
+                        check=False,
+                    )
+                except FileNotFoundError as exc:
+                    raise RuntimeError(
+                        f"codex executable not found: {self.codex_bin}"
+                    ) from exc
+                except subprocess.TimeoutExpired as exc:
+                    raise RuntimeError(
+                        f"Codex translator timed out after {self.timeout} seconds."
+                    ) from exc
+
+                if result.returncode == 0:
+                    if mode == "compat":
+                        self.preferred_command_mode = "compat"
+                    return response_loader(output_path)
+
+                detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
+                last_error = RuntimeError(
+                    f"Codex translator failed with exit code {result.returncode}: {detail}"
+                )
+                if (
+                    mode == "fast"
+                    and "compat" in modes
+                    and self._looks_like_unsupported_flag(detail)
+                ):
+                    self.preferred_command_mode = "compat"
+                    continue
+                raise last_error
+
+            raise last_error
+
+    def _run_single_translation(self, text: str) -> str:
+        prompt_text = self._build_codex_prompt(text)
+        return self._execute_codex_request(
+            prompt_text, self.single_output_schema, self._load_translation
+        )
+
+    def _chunk_batch(self, texts: list[tuple[int, str]]) -> list[list[tuple[int, str]]]:
+        batches = []
+        current_batch = []
+        current_chars = 0
+        for item in texts:
+            _, text = item
+            text_len = len(text)
+            if current_batch and (
+                len(current_batch) >= self.MAX_BATCH_ITEMS
+                or current_chars + text_len > self.MAX_BATCH_CHARS
+            ):
+                batches.append(current_batch)
+                current_batch = []
+                current_chars = 0
+            current_batch.append(item)
+            current_chars += text_len
+        if current_batch:
+            batches.append(current_batch)
+        return batches
+
+    def _split_long_text(self, text: str) -> list[str]:
+        if len(text) <= self.MAX_ITEM_CHARS:
+            return [text]
+
+        sentence_like_parts = []
+        cursor = 0
+        for match in re.finditer(r".*?(?:[.!?;:](?:\s+|$)|$)", text, flags=re.DOTALL):
+            part = match.group(0)
+            if not part:
+                continue
+            sentence_like_parts.append(part)
+            cursor = match.end()
+            if cursor >= len(text):
+                break
+        if not sentence_like_parts:
+            sentence_like_parts = [text]
+
+        chunks = []
+        current = ""
+        for part in sentence_like_parts:
+            if len(part) > self.MAX_ITEM_CHARS:
+                if current:
+                    chunks.append(current)
+                    current = ""
+                remaining = part
+                while len(remaining) > self.MAX_ITEM_CHARS:
+                    split_at = remaining.rfind(" ", 0, self.MAX_ITEM_CHARS)
+                    if split_at <= 0:
+                        split_at = self.MAX_ITEM_CHARS
+                    chunks.append(remaining[:split_at])
+                    remaining = remaining[split_at:]
+                if remaining:
+                    current = remaining
+                continue
+
+            if current and len(current) + len(part) > self.MAX_ITEM_CHARS:
+                chunks.append(current)
+                current = part
+            else:
+                current += part
+
+        if current:
+            chunks.append(current)
+        return [chunk for chunk in chunks if chunk]
+
+    def _run_batch_translation(self, texts: list[str]) -> list[str]:
+        prompt_text = self._build_batch_prompt(texts)
+        try:
+            return self._execute_codex_request(
+                prompt_text,
+                self.batch_output_schema,
+                lambda output_path: self._load_batch_translations(
+                    output_path, len(texts)
+                ),
+            )
+        except RuntimeError as exc:
+            if len(texts) == 1:
+                return [self._run_single_translation(texts[0])]
+            detail = str(exc)
+            if (
+                "translations" not in detail
+                and "same length" not in detail
+                and "empty items" not in detail
+                and "timed out" not in detail
+            ):
+                raise
+            midpoint = len(texts) // 2
+            return self._run_batch_translation(texts[:midpoint]) + self._run_batch_translation(
+                texts[midpoint:]
+            )
+
+    @staticmethod
+    def _recombine_translated_segments(
+        source_segments: list[str], translated_segments: list[str]
+    ) -> str:
+        combined = ""
+        for idx, translated in enumerate(translated_segments):
+            cleaned = translated.strip()
+            if idx == 0:
+                combined = cleaned
+                continue
+            previous_source = source_segments[idx - 1]
+            current_source = source_segments[idx]
+            boundary_match = re.search(r"(\s+)$", previous_source) or re.match(
+                r"^(\s+)", current_source
+            )
+            boundary = boundary_match.group(1) if boundary_match else ""
+            if boundary and not combined.endswith(boundary):
+                combined += boundary
+            combined += cleaned
+        return combined
+
+    def _normalize_translation_output(self, text: str) -> str:
+        if self.lang_out.lower() not in {"zh", "zh-cn", "zh-tw", "zh-hans", "zh-hant"}:
+            return text
+
+        pairs = [
+            (self.CJK_CHAR_RE, self.CJK_CHAR_RE),
+            (self.CJK_CHAR_RE, self.CJK_PUNCT_RE),
+            (self.CJK_PUNCT_RE, self.CJK_CHAR_RE),
+            (self.CJK_CHAR_RE, self.PLACEHOLDER_RE),
+            (self.PLACEHOLDER_RE, self.CJK_CHAR_RE),
+            (self.CJK_PUNCT_RE, self.PLACEHOLDER_RE),
+            (self.PLACEHOLDER_RE, self.CJK_PUNCT_RE),
+        ]
+        normalized = text
+        changed = True
+        while changed:
+            previous = normalized
+            for left, right in pairs:
+                normalized = re.sub(
+                    fr"({left}){self.HSPACE_RE}({right})", r"\1\2", normalized
+                )
+            changed = normalized != previous
+        return normalized
+
+    def do_translate(self, text: str) -> str:
+        return self._run_single_translation(text)
+
+    def translate_batch(
+        self, texts: list[str], ignore_cache: bool = False
+    ) -> list[str]:
+        if self.prompttext:
+            return BaseTranslator.translate_batch(self, texts, ignore_cache=ignore_cache)
+
+        results = [None] * len(texts)
+        pending_items = []
+        for idx, text in enumerate(texts):
+            if self._is_passthrough_text(text):
+                results[idx] = text
+                continue
+            if not (self.ignore_cache or ignore_cache):
+                cache_result = self.cache.get(text)
+                if cache_result is not None:
+                    results[idx] = cache_result
+                    continue
+            pending_items.append((idx, text))
+
+        if pending_items:
+            expanded_items = []
+            segment_sources: dict[int, list[str]] = {}
+            recombine_map: dict[int, list[int]] = {}
+            expanded_index = 0
+            for original_idx, source_text in pending_items:
+                segments = self._split_long_text(source_text)
+                segment_sources[original_idx] = segments
+                recombine_map[original_idx] = []
+                for segment in segments:
+                    expanded_items.append((expanded_index, segment))
+                    recombine_map[original_idx].append(expanded_index)
+                    expanded_index += 1
+
+            expanded_results: dict[int, str] = {}
+            for batch in self._chunk_batch(expanded_items):
+                batch_texts = [text for _, text in batch]
+                translated_batch = self._run_batch_translation(batch_texts)
+                for (batch_idx, _source_text), translated_text in zip(batch, translated_batch):
+                    expanded_results[batch_idx] = translated_text
+
+            for original_idx, source_text in pending_items:
+                segment_indices = recombine_map[original_idx]
+                translated_segments = [
+                    expanded_results[segment_idx] for segment_idx in segment_indices
+                ]
+                combined_translation = self._recombine_translated_segments(
+                    segment_sources[original_idx], translated_segments
+                )
+                combined_translation = self._normalize_translation_output(
+                    combined_translation
+                )
+                results[original_idx] = combined_translation
+                self.cache.set(source_text, combined_translation)
+
+        return [text if result is None else result for text, result in zip(texts, results)]
+
+    def get_formular_placeholder(self, id: int):
+        return "{{v" + str(id) + "}}"
+
+    def get_rich_text_left_placeholder(self, id: int):
+        return self.get_formular_placeholder(id)
+
+    def get_rich_text_right_placeholder(self, id: int):
+        return self.get_formular_placeholder(id + 1)
 
 
 class QwenMtTranslator(OpenAITranslator):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,246 @@
+import sys
+import types
+import importlib
+
+
+def _ensure_module(name: str) -> types.ModuleType:
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        sys.modules[name] = module
+    return module
+
+
+def _stub_deepl():
+    module = _ensure_module("deepl")
+
+    class Translator:
+        def __init__(self, auth_key):
+            self.auth_key = auth_key
+
+        def translate_text(self, text, target_lang=None, source_lang=None):
+            return types.SimpleNamespace(text=text)
+
+    module.Translator = Translator
+
+
+def _stub_ollama():
+    module = _ensure_module("ollama")
+
+    class ResponseError(Exception):
+        pass
+
+    class Client:
+        def __init__(self, host=None):
+            self.host = host
+
+        def chat(self, **kwargs):
+            return types.SimpleNamespace(
+                message=types.SimpleNamespace(content=kwargs.get("messages", [{}])[0].get("content", ""))
+            )
+
+    module.ResponseError = ResponseError
+    module.Client = Client
+
+
+def _stub_openai():
+    module = _ensure_module("openai")
+
+    class RateLimitError(Exception):
+        pass
+
+    class BadRequestError(Exception):
+        pass
+
+    class _ChatCompletions:
+        def create(self, **kwargs):
+            content = kwargs.get("messages", [{}])[0].get("content", "")
+            return types.SimpleNamespace(
+                choices=[
+                    types.SimpleNamespace(
+                        message=types.SimpleNamespace(content=content),
+                        delta=types.SimpleNamespace(content=content),
+                    )
+                ]
+            )
+
+    class _Chat:
+        def __init__(self):
+            self.completions = _ChatCompletions()
+
+    class OpenAI:
+        def __init__(self, base_url=None, api_key=None):
+            self.base_url = base_url
+            self.api_key = api_key
+            self.chat = _Chat()
+
+    class AzureOpenAI(OpenAI):
+        def __init__(self, azure_endpoint=None, azure_deployment=None, api_version=None, api_key=None):
+            super().__init__(base_url=azure_endpoint, api_key=api_key)
+            self.azure_deployment = azure_deployment
+            self.api_version = api_version
+
+    module.OpenAI = OpenAI
+    module.AzureOpenAI = AzureOpenAI
+    module.RateLimitError = RateLimitError
+    module.BadRequestError = BadRequestError
+
+
+def _stub_xinference_client():
+    module = _ensure_module("xinference_client")
+
+    class RESTfulClient:
+        def __init__(self, host):
+            self.host = host
+
+        def get_model(self, model):
+            return types.SimpleNamespace(
+                chat=lambda **kwargs: {"choices": [{"message": {"content": ""}}]}
+            )
+
+    module.RESTfulClient = RESTfulClient
+
+
+def _stub_azure():
+    azure = _ensure_module("azure")
+    azure.ai = _ensure_module("azure.ai")
+    azure.ai.translation = _ensure_module("azure.ai.translation")
+    text_module = _ensure_module("azure.ai.translation.text")
+    azure.core = _ensure_module("azure.core")
+    azure.core.credentials = _ensure_module("azure.core.credentials")
+
+    class TextTranslationClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def translate(self, body=None, from_language=None, to_language=None):
+            translation = types.SimpleNamespace(text=body[0] if body else "")
+            return [types.SimpleNamespace(translations=[translation])]
+
+    class AzureKeyCredential:
+        def __init__(self, key):
+            self.key = key
+
+    text_module.TextTranslationClient = TextTranslationClient
+    azure.core.credentials.AzureKeyCredential = AzureKeyCredential
+
+
+def _stub_tencentcloud():
+    tencentcloud = _ensure_module("tencentcloud")
+    tencentcloud.common = _ensure_module("tencentcloud.common")
+    credential_module = _ensure_module("tencentcloud.common.credential")
+    tencentcloud.tmt = _ensure_module("tencentcloud.tmt")
+    v20180321 = _ensure_module("tencentcloud.tmt.v20180321")
+    models_module = _ensure_module("tencentcloud.tmt.v20180321.models")
+    tmt_client_module = _ensure_module("tencentcloud.tmt.v20180321.tmt_client")
+
+    class DefaultCredentialProvider:
+        def get_credential(self):
+            raise EnvironmentError
+
+    class Credential:
+        def __init__(self, secret_id=None, secret_key=None):
+            self.secret_id = secret_id
+            self.secret_key = secret_key
+
+    class TextTranslateRequest:
+        def __init__(self):
+            self.Source = None
+            self.Target = None
+            self.ProjectId = 0
+            self.SourceText = ""
+
+    class TextTranslateResponse:
+        def __init__(self, target_text=""):
+            self.TargetText = target_text
+
+    class TmtClient:
+        def __init__(self, cred, region):
+            self.cred = cred
+            self.region = region
+
+        def TextTranslate(self, req):
+            return TextTranslateResponse(req.SourceText)
+
+    credential_module.DefaultCredentialProvider = DefaultCredentialProvider
+    credential_module.Credential = Credential
+    models_module.TextTranslateRequest = TextTranslateRequest
+    models_module.TextTranslateResponse = TextTranslateResponse
+    tmt_client_module.TmtClient = TmtClient
+    v20180321.models = models_module
+    v20180321.tmt_client = tmt_client_module
+
+
+def _stub_gradio_pdf():
+    module = _ensure_module("gradio_pdf")
+
+    class PDF:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    module.PDF = PDF
+
+
+def _stub_babeldoc():
+    module = _ensure_module("babeldoc")
+    module.__version__ = "0.0-test"
+    docvision = _ensure_module("babeldoc.docvision")
+    doclayout_module = _ensure_module("babeldoc.docvision.doclayout")
+
+    class OnnxModel:
+        @staticmethod
+        def load_available():
+            return types.SimpleNamespace()
+
+    doclayout_module.OnnxModel = OnnxModel
+    docvision.doclayout = doclayout_module
+
+
+def _stub_pdf2zh_doclayout():
+    pdf2zh_pkg = importlib.import_module("pdf2zh")
+    module = _ensure_module("pdf2zh.doclayout")
+
+    class OnnxModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @staticmethod
+        def load_available():
+            return types.SimpleNamespace()
+
+    def set_backend(_backend):
+        return None
+
+    module.OnnxModel = getattr(module, "OnnxModel", OnnxModel)
+    module.ModelInstance = getattr(
+        module, "ModelInstance", types.SimpleNamespace(value=None)
+    )
+    module.set_backend = getattr(module, "set_backend", set_backend)
+    setattr(pdf2zh_pkg, "doclayout", module)
+
+
+def _stub_pdf2zh_high_level():
+    pdf2zh_pkg = importlib.import_module("pdf2zh")
+    module = _ensure_module("pdf2zh.high_level")
+
+    def translate(**kwargs):
+        return []
+
+    def translate_stream(stream=None, **kwargs):
+        return b"", b""
+
+    module.translate = getattr(module, "translate", translate)
+    module.translate_stream = getattr(module, "translate_stream", translate_stream)
+    setattr(pdf2zh_pkg, "high_level", module)
+
+
+_stub_deepl()
+_stub_ollama()
+_stub_openai()
+_stub_xinference_client()
+_stub_azure()
+_stub_tencentcloud()
+_stub_gradio_pdf()
+_stub_babeldoc()
+_stub_pdf2zh_doclayout()
+_stub_pdf2zh_high_level()

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -1,8 +1,10 @@
 import unittest
 from unittest.mock import Mock, patch, MagicMock
+from types import SimpleNamespace
 from pdfminer.layout import LTPage, LTChar, LTLine
 from pdfminer.pdfinterp import PDFResourceManager
 from pdf2zh.converter import PDFConverterEx, TranslateConverter
+from pdf2zh.translator import CodexTranslator
 
 
 class TestPDFConverterEx(unittest.TestCase):
@@ -104,6 +106,57 @@ class TestTranslateConverter(unittest.TestCase):
                 lang_out="zh",
                 service="InvalidService",
             )
+
+    def test_codex_translation_service(self):
+        with patch.object(CodexTranslator, "_probe_cli", return_value=None):
+            converter = TranslateConverter(
+                self.rsrcmgr,
+                layout=self.layout,
+                lang_in="en",
+                lang_out="zh",
+                service="codex",
+            )
+        self.assertIsInstance(converter.translator, CodexTranslator)
+
+    @patch.object(CodexTranslator, "_probe_cli", return_value=None)
+    def test_codex_translate_segments_uses_batch_path(self, _mock_probe):
+        converter = TranslateConverter(
+            self.rsrcmgr,
+            layout=self.layout,
+            lang_in="en",
+            lang_out="zh",
+            service="codex",
+        )
+        converter.thread = 4
+        converter.translator = SimpleNamespace(
+            name="codex",
+            translate_batch=Mock(return_value=["甲", "乙"]),
+        )
+
+        result = converter._translate_text_segments(["a", "{v1}", "b", " "])
+
+        self.assertEqual(["甲", "{v1}", "乙", " "], result)
+        converter.translator.translate_batch.assert_called_once_with(["a", "b"])
+
+    @patch.object(CodexTranslator, "_probe_cli", return_value=None)
+    def test_codex_translate_segments_retries_transient_batch_errors(self, _mock_probe):
+        converter = TranslateConverter(
+            self.rsrcmgr,
+            layout=self.layout,
+            lang_in="en",
+            lang_out="zh",
+            service="codex",
+        )
+        converter.thread = 1
+        converter.translator = SimpleNamespace(
+            name="codex",
+            translate_batch=Mock(side_effect=[RuntimeError("temporary"), ["甲", "乙"]]),
+        )
+
+        result = converter._translate_text_segments(["a", "b"])
+
+        self.assertEqual(["甲", "乙"], result)
+        self.assertEqual(2, converter.translator.translate_batch.call_count)
 
 
 if __name__ == "__main__":

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -1,4 +1,8 @@
 import unittest
+import json
+import subprocess
+from pathlib import Path
+from string import Template
 from textwrap import dedent
 from unittest import mock
 
@@ -6,7 +10,12 @@ from ollama import ResponseError as OllamaResponseError
 
 from pdf2zh import cache
 from pdf2zh.config import ConfigManager
-from pdf2zh.translator import BaseTranslator, OllamaTranslator, OpenAIlikedTranslator
+from pdf2zh.translator import (
+    BaseTranslator,
+    CodexTranslator,
+    OllamaTranslator,
+    OpenAIlikedTranslator,
+)
 
 # Since it is necessary to test whether the functionality meets the expected requirements,
 # private functions and private methods are allowed to be called.
@@ -218,6 +227,435 @@ class TestOllamaTranslator(unittest.TestCase):
         self.assertEqual(
             excepted_not_retain_cot_content, only_removed_cot_content.strip()
         )
+
+
+class TestCodexTranslator(unittest.TestCase):
+    def setUp(self):
+        self.test_db = cache.init_test_db()
+        ConfigManager.clear()
+
+    def tearDown(self):
+        cache.clean_test_db(self.test_db)
+        ConfigManager.clear()
+
+    @staticmethod
+    def _write_translation_payload(cmd, translation):
+        output_path = cmd[cmd.index("--output-last-message") + 1]
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump({"translation": translation}, f)
+
+    @staticmethod
+    def _write_batch_translation_payload(cmd, translations):
+        output_path = cmd[cmd.index("--output-last-message") + 1]
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump({"translations": translations}, f)
+
+    @staticmethod
+    def _probe_side_effect(extra=None):
+        extra = extra or []
+
+        def side_effect(cmd, **kwargs):
+            if cmd[1:] == ["--version"]:
+                return subprocess.CompletedProcess(cmd, 0, "codex 0.122.0\n", "")
+            if cmd[1:] == ["exec", "--help"]:
+                help_text = "\n".join(
+                    [
+                        "--skip-git-repo-check",
+                        "--ephemeral",
+                        "--sandbox",
+                        "--color",
+                        "--output-schema",
+                        "--output-last-message",
+                        "--ignore-user-config",
+                        "--ignore-rules",
+                        "--model",
+                        "--profile",
+                        "--config",
+                    ]
+                )
+                return subprocess.CompletedProcess(cmd, 0, help_text, "")
+            if extra:
+                return extra.pop(0)(cmd, **kwargs)
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        return side_effect
+
+    def test_do_translate_builds_default_codex_command(self):
+        cwd_capture = {}
+
+        def fake_run(cmd, **kwargs):
+            cwd_capture["cwd"] = kwargs["cwd"]
+            self.assertNotEqual(kwargs["cwd"], ".")
+            self.assertTrue("--ephemeral" in cmd)
+            self.assertTrue("--skip-git-repo-check" in cmd)
+            self.assertTrue("--sandbox" in cmd)
+            self.assertTrue("--output-schema" in cmd)
+            self.assertTrue("--output-last-message" in cmd)
+            self._write_translation_payload(cmd, "你好，世界")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=self._probe_side_effect([fake_run]),
+        ) as run:
+            translator = CodexTranslator(lang_in="en", lang_out="zh", model=None)
+            translated = translator.do_translate("Hello, world")
+
+        self.assertEqual("你好，世界", translated)
+        cmd = run.call_args.args[0]
+        self.assertEqual("codex", cmd[0])
+        self.assertEqual(["exec"], cmd[1:2])
+        self.assertNotEqual(cwd_capture["cwd"], None)
+        self.assertEqual(run.call_args.kwargs["timeout"], 120)
+        self.assertIs(run.call_args.kwargs["stdin"], subprocess.DEVNULL)
+        self.assertIn("--ignore-user-config", cmd)
+        self.assertIn("--ignore-rules", cmd)
+        self.assertIn("-c", cmd)
+        self.assertIn('model_reasoning_effort="none"', cmd)
+        self.assertIn("gpt-5.4-mini", cmd)
+
+    def test_do_translate_honors_profile_model_and_timeout(self):
+        envs = {
+            "CODEX_BIN": "/usr/local/bin/codex",
+            "CODEX_PROFILE": "translate",
+            "CODEX_MODEL": "gpt-5.4-mini",
+            "CODEX_TIMEOUT": "37",
+        }
+
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_translation_payload(cmd, "测试"),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1]
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None, envs=envs)
+            translated = translator.do_translate("test")
+
+        self.assertEqual("测试", translated)
+        cmd = run.call_args.args[0]
+        self.assertEqual("/usr/local/bin/codex", cmd[0])
+        self.assertNotIn("--ignore-user-config", cmd)
+        self.assertIn("--profile", cmd)
+        self.assertIn("translate", cmd)
+        self.assertIn("--model", cmd)
+        self.assertIn("gpt-5.4-mini", cmd)
+        self.assertEqual(run.call_args.kwargs["timeout"], 37)
+
+    def test_init_fails_when_required_codex_flags_missing(self):
+        def side_effect(cmd, **kwargs):
+            if cmd[1:] == ["--version"]:
+                return subprocess.CompletedProcess(cmd, 0, "codex 0.122.0\n", "")
+            if cmd[1:] == ["exec", "--help"]:
+                return subprocess.CompletedProcess(cmd, 0, "--model\n", "")
+            raise AssertionError(f"Unexpected command: {cmd}")
+
+        with mock.patch("pdf2zh.translator.subprocess.run", side_effect=side_effect):
+            with self.assertRaises(RuntimeError) as context:
+                CodexTranslator("en", "zh", None)
+
+        self.assertIn("--output-schema", str(context.exception))
+
+    def test_do_translate_falls_back_to_compat_path_on_unsupported_flag(self):
+        run_calls = []
+
+        def compat_run(cmd, **kwargs):
+            run_calls.append(cmd)
+            if "--ignore-user-config" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 2, "", "error: unexpected argument '--ignore-user-config'"
+                )
+            self._write_translation_payload(cmd, "兼容路径")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=self._probe_side_effect([compat_run, compat_run]),
+        ):
+            translator = CodexTranslator("en", "zh", None)
+            translated = translator.do_translate("test")
+
+        self.assertEqual("兼容路径", translated)
+        self.assertEqual(2, len(run_calls))
+        self.assertIn("--ignore-user-config", run_calls[0])
+        self.assertNotIn("--ignore-user-config", run_calls[1])
+
+    def test_translate_batch_returns_cached_and_batched_values(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["甲", "乙"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1]
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            translator.cache.set("cached", "已缓存")
+            translated = translator.translate_batch(["cached", "a", "{v1}", "b", " "])
+
+        self.assertEqual(["已缓存", "甲", "{v1}", "乙", " "], translated)
+        cmd = run.call_args.args[0]
+        self.assertIn("--output-schema", cmd)
+        self.assertEqual("甲", translator.cache.get("a"))
+        self.assertEqual("乙", translator.cache.get("b"))
+
+    def test_translate_batch_splits_and_retries_on_mismatched_length(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["only-one"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["甲"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["乙"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            translated = translator.translate_batch(["a", "b"])
+
+        self.assertEqual(["甲", "乙"], translated)
+
+    def test_translate_batch_splits_and_retries_on_timeout(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (_ for _ in ()).throw(
+                        subprocess.TimeoutExpired(cmd, 120)
+                    ),
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["甲"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, ["乙"]),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            translated = translator.translate_batch(["a", "b"])
+
+        self.assertEqual(["甲", "乙"], translated)
+
+    def test_translate_batch_uses_single_translate_when_custom_prompt_present(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_translation_payload(cmd, "一"),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                    lambda cmd, **kwargs: (
+                        self._write_translation_payload(cmd, "二"),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                ]
+            )
+            translator = CodexTranslator(
+                "en", "zh", None, prompt=Template("Custom: ${text}")
+            )
+            translated = translator.translate_batch(["a", "b"])
+
+        self.assertEqual(["一", "二"], translated)
+        self.assertEqual(4, run.call_count)
+
+    def test_translate_batch_splits_long_items_and_recombines(self):
+        long_text = ("Sentence one. " * 120).strip()
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(
+                            cmd, ["甲", "乙", "丙", "丁", "戊", "己"]
+                        ),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1]
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            translated = translator.translate_batch([long_text])
+
+        self.assertEqual(["甲乙丙丁戊己"], translated)
+
+    def test_recombine_translated_segments_preserves_whitespace_boundaries(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+
+        combined = translator._recombine_translated_segments(
+            ["Hello ", "world"], ["你好", "世界"]
+        )
+        self.assertEqual("你好 世界", combined)
+
+        combined_newline = translator._recombine_translated_segments(
+            ["Hello\n", "world"], ["你好", "世界"]
+        )
+        self.assertEqual("你好\n世界", combined_newline)
+
+        combined_tabs = translator._recombine_translated_segments(
+            ["Hello\t\t", "world"], ["你好", "世界"]
+        )
+        self.assertEqual("你好\t\t世界", combined_tabs)
+
+    def test_normalize_translation_output_removes_chinese_word_spaces(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+
+        normalized = translator._normalize_translation_output(
+            "本文 提出 了一种 复合 控制 策略 ， 用于 实现 轨迹 跟踪 任务 。"
+        )
+        self.assertEqual("本文提出了一种复合控制策略，用于实现轨迹跟踪任务。", normalized)
+
+    def test_normalize_translation_output_preserves_english_boundary(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+
+        normalized = translator._normalize_translation_output(
+            "MPC 跟踪 控制 对象"
+        )
+        self.assertEqual("MPC 跟踪控制对象", normalized)
+
+    def test_normalize_translation_output_removes_placeholder_spaces(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+
+        normalized = translator._normalize_translation_output(
+            "代价 函数 {v1} 最小 化 ， 约束 {v2} 满足 。"
+        )
+        self.assertEqual("代价函数{v1}最小化，约束{v2}满足。", normalized)
+
+    def test_capability_probe_caches_fast_path_support(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+
+        self.assertTrue(translator.fast_command_available)
+        self.assertTrue(translator.compat_command_available)
+        self.assertEqual("fast", translator.preferred_command_mode)
+        self.assertIn("--output-schema", translator.supported_exec_flags)
+
+    def test_init_raises_when_codex_binary_missing(self):
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=FileNotFoundError("codex not found"),
+        ):
+            with self.assertRaises(RuntimeError) as context:
+                CodexTranslator("en", "zh", None)
+
+        self.assertIn("codex executable not found", str(context.exception))
+
+    def test_do_translate_raises_on_non_zero_exit(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_translation_payload(cmd, "ignored"),
+                        subprocess.CompletedProcess(cmd, 1, "", "boom"),
+                    )[1]
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            with self.assertRaises(RuntimeError) as context:
+                translator.do_translate("Hello")
+
+        self.assertIn("boom", str(context.exception))
+
+    def test_do_translate_raises_on_invalid_json(self):
+        def fake_run(cmd, **kwargs):
+            output_path = cmd[cmd.index("--output-last-message") + 1]
+            with open(output_path, "w", encoding="utf-8") as f:
+                f.write("not-json")
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=self._probe_side_effect([fake_run]),
+        ):
+            translator = CodexTranslator("en", "zh", None)
+            with self.assertRaises(RuntimeError) as context:
+                translator.do_translate("Hello")
+
+        self.assertIn("invalid JSON", str(context.exception))
+
+    def test_do_translate_raises_on_missing_translation_field(self):
+        def fake_run(cmd, **kwargs):
+            output_path = cmd[cmd.index("--output-last-message") + 1]
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump({"message": "missing"}, f)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=self._probe_side_effect([fake_run]),
+        ):
+            translator = CodexTranslator("en", "zh", None)
+            with self.assertRaises(RuntimeError) as context:
+                translator.do_translate("Hello")
+
+        self.assertIn("translation", str(context.exception))
+
+    def test_do_translate_raises_on_missing_batch_field(self):
+        def fake_run(cmd, **kwargs):
+            output_path = cmd[cmd.index("--output-last-message") + 1]
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump({}, f)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+
+        with mock.patch(
+            "pdf2zh.translator.subprocess.run",
+            side_effect=self._probe_side_effect(
+                [fake_run, fake_run, fake_run, fake_run, fake_run]
+            ),
+        ):
+            translator = CodexTranslator("en", "zh", None)
+            with self.assertRaises(RuntimeError) as context:
+                translator.translate_batch(["Hello", "World"])
+
+        self.assertIn("translation", str(context.exception))
+
+    def test_single_item_batch_falls_back_to_single_translate(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect(
+                [
+                    lambda cmd, **kwargs: (
+                        self._write_batch_translation_payload(cmd, []),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1],
+                    lambda cmd, **kwargs: (
+                        self._write_translation_payload(cmd, "单条回退"),
+                        subprocess.CompletedProcess(cmd, 0, "", ""),
+                    )[1]
+                ]
+            )
+            translator = CodexTranslator("en", "zh", None)
+            translated = translator.translate_batch(["a"])
+
+        self.assertEqual(["单条回退"], translated)
+
+    def test_codex_uses_llm_placeholders(self):
+        with mock.patch("pdf2zh.translator.subprocess.run") as run:
+            run.side_effect = self._probe_side_effect()
+            translator = CodexTranslator("en", "zh", None)
+        self.assertEqual("{{v3}}", translator.get_formular_placeholder(3))
+        self.assertEqual("{{v3}}", translator.get_rich_text_left_placeholder(3))
+        self.assertEqual("{{v4}}", translator.get_rich_text_right_placeholder(3))
+
+    def test_gui_service_map_includes_codex(self):
+        gui_source = Path("pdf2zh/gui.py").read_text(encoding="utf-8")
+        self.assertIn('"Codex": CodexTranslator', gui_source)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

This PR adds a local Codex-based translation path for PDFMathTranslate, so users can translate PDFs through the local Codex CLI without wiring up any external translation API key.

Key changes:
- add a built-in `codex` translator that uses the local Codex CLI
- keep the existing CLI and GUI service entry points intact
- add capability probing plus fast/compat command selection for the local CLI path
- add bounded batch translation, long-text splitting, retry, and fallback behavior so full PDFs can complete reliably
- force effective concurrency to `1` for the local CLI path instead of following the generic thread fanout
- add whitespace normalization for Chinese output so unnecessary spaces between Chinese words and punctuation are removed

## Why this changed

The main goal is to make Codex usable as a local translation backend out of the box.

Before this change, users who wanted a Codex-style workflow still had to rely on external translation APIs or on a fragile short-text-only prototype. This PR makes the local CLI path practical for end-to-end PDF translation while keeping the integration surface simple.

## User impact

Users can now translate with:

- local Codex CLI
- existing Codex login state
- no user-provided translation API key

Notable behavior:
- `pdf2zh file.pdf -s codex` is supported
- GUI keeps exposing `Codex`
- the local CLI translator batches text internally for better full-PDF throughput
- effective concurrency is fixed to `1` for this translator path
- Chinese output spacing is cleaned up before the translated PDF is written

## Validation

Automated:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 /opt/anaconda3/bin/python3.12 -m pytest test/test_translator.py test/test_converter.py test/test_kernel.py -q`
- `/opt/anaconda3/bin/python3.12 -m compileall pdf2zh test`

Live checks:
- single-string smoke translation
- multi-item batch smoke translation
- long-text batch smoke translation
- full target PDF smoke run producing mono and dual outputs for `MPC 跟踪控制.pdf`
