### PR TITLE
fix(gui): support translator internal name in ENABLED_SERVICES config

### DIFF
--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -144,8 +144,9 @@ if isinstance(enabled_services, list):
     enabled_services_names = [str(_).lower().strip() for _ in enabled_services]
     enabled_services = [
         k
-        for k in service_map.keys()
+        for k, v in service_map.items()
         if str(k).lower().strip() in enabled_services_names
+        or (hasattr(v, "name") and str(v.name).lower().strip() in enabled_services_names)
     ]
     if len(enabled_services) == 0:
         raise RuntimeError("No services available.")


### PR DESCRIPTION
Fixes #1108

## Problem

When configuring `ENABLED_SERVICES` in the config file, users must use the UI display name (e.g. `"Ali Qwen-Translation"`) to enable a service. However, translators also have an internal `name` attribute (e.g. `"qwen-mt"` for `QwenMtTranslator`), which is the name used in the `translators` list of the config file. This mismatch is confusing — users naturally try using the same name (`"qwen-mt"`) in both `ENABLED_SERVICES` and `translators`, but only the `translators` lookup works with the internal name.

## Solution

Extend the `ENABLED_SERVICES` filter in `gui.py` to match services by either their display name (the service_map key) or their translator internal `name` attribute. This way both of the following configs work:

```json
// Using display name
"ENABLED_SERVICES": ["Ali Qwen-Translation"]

// Using internal translator name (now also supported)
"ENABLED_SERVICES": ["qwen-mt"]
```

## Testing

- Verified with a quick logic test that `"qwen-mt"` now resolves to `"Ali Qwen-Translation"` in the service list
- Verified backward compatibility: existing configs using display names continue to work