### PR TITLE
fix(high_level): gracefully handle subset_fonts failures

### DIFF
--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -244,8 +244,18 @@ def translate_stream(
     for id in range(page_count):
         doc_en.move_page(page_count + id, id * 2 + 1)
     if not skip_subset_fonts:
-        doc_zh.subset_fonts(fallback=True)
-        doc_en.subset_fonts(fallback=True)
+        try:
+            doc_zh.subset_fonts(fallback=True)
+        except Exception:
+            logger.warning(
+                "Failed to subset fonts in translated document; output may be larger than expected"
+            )
+        try:
+            doc_en.subset_fonts(fallback=True)
+        except Exception:
+            logger.warning(
+                "Failed to subset fonts in bilingual document; output may be larger than expected"
+            )
     return (
         doc_zh.write(deflate=True, garbage=3, use_objstms=1),
         doc_en.write(deflate=True, garbage=3, use_objstms=1),


### PR DESCRIPTION
Fixes #975

## Problem

When `doc.subset_fonts(fallback=True)` is called during PDF generation, PyMuPDF may raise `ValueError: bad 'value'` for certain PDFs that have malformed font width tables. This causes the entire translation to crash at the very end — after all translation work has already completed — producing no output file.

Stack trace from the issue:
```
File "pymupdf/utils.py", line 5848, in subset_fonts
    set_old_widths(font_xref, width_table, def_width)
File "pymupdf/utils.py", line 5617, in set_old_widths
    doc.xref_set_key(df_xref, "DW", dwidths)
ValueError: bad 'value'
```

## Solution

Wrap each `subset_fonts()` call in a `try-except` block. If font subsetting fails, log a warning and continue — the output PDF is still written successfully. The only downside is a slightly larger file size when font subsetting is skipped.

## Testing

- Verified the fix allows translation to complete when `subset_fonts` raises a `ValueError`
- Existing behavior is preserved for PDFs where font subsetting succeeds