### PR TITLE
Feat/add litellm provider

### DIFF
--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -30,6 +30,7 @@ from pdf2zh.translator import (
     GoogleTranslator,
     GrokTranslator,
     GroqTranslator,
+    LiteLLMTranslator,
     MiniMaxTranslator,
     ModelScopeTranslator,
     OllamaTranslator,
@@ -161,7 +162,7 @@ class TranslateConverter(PDFConverterEx):
         if not envs:
             envs = {}
         for translator in [GoogleTranslator, BingTranslator, DeepLTranslator, DeepLXTranslator, OllamaTranslator, XinferenceTranslator, AzureOpenAITranslator,
-                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, QwenMtTranslator, X302AITranslator]:
+                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, QwenMtTranslator, X302AITranslator, LiteLLMTranslator]:
             if service_name == translator.name:
                 self.translator = translator(lang_in, lang_out, service_model, envs=envs, prompt=prompt, ignore_cache=ignore_cache)
         if not self.translator:

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -41,6 +41,7 @@ from pdf2zh.translator import (
     ZhipuTranslator,
     GrokTranslator,
     GroqTranslator,
+    LiteLLMTranslator,
     DeepseekTranslator,
     OpenAIlikedTranslator,
     QwenMtTranslator,
@@ -96,6 +97,7 @@ service_map: dict[str, BaseTranslator] = {
     "OpenAI-liked": OpenAIlikedTranslator,
     "Ali Qwen-Translation": QwenMtTranslator,
     "302.AI": X302AITranslator,
+    "LiteLLM": LiteLLMTranslator,
 }
 
 # The following variables associate strings with specific languages
@@ -427,6 +429,7 @@ def babeldoc_translate_file(**kwargs):
         OpenAIlikedTranslator,
         QwenMtTranslator,
         X302AITranslator,
+        LiteLLMTranslator,
     ]:
         if kwargs["service"] == translator.name:
             translator = translator(
@@ -459,7 +462,9 @@ def babeldoc_translate_file(**kwargs):
             no_mono=False,
             qps=kwargs["thread"],
             use_rich_pbar=False,
-            disable_rich_text_translate=not isinstance(translator, OpenAITranslator),
+            disable_rich_text_translate=not isinstance(
+                translator, (OpenAITranslator, LiteLLMTranslator)
+            ),
             skip_clean=kwargs["skip_subset_fonts"],
             report_interval=0.5,
         )

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -437,6 +437,7 @@ def yadt_main(parsed_args) -> int:
         OpenAIlikedTranslator,
         QwenMtTranslator,
         X302AITranslator,
+        LiteLLMTranslator,
     )
 
     for translator in [
@@ -463,6 +464,7 @@ def yadt_main(parsed_args) -> int:
         OpenAIlikedTranslator,
         QwenMtTranslator,
         X302AITranslator,
+        LiteLLMTranslator,
     ]:
         if service_name == translator.name:
             translator = translator(

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1238,8 +1238,6 @@ class LiteLLMTranslator(BaseTranslator):
         think_filter_regex = r"^<think>.+?\n*(</think>|\n)*(</think>)\n*"
         self.add_cache_impact_parameters("think_filter_regex", think_filter_regex)
         self.think_filter_regex = re.compile(think_filter_regex, flags=re.DOTALL)
-        stream_val = self.envs.get("LITELLM_STREAM", "true").lower()
-        self.stream = stream_val == "true"
 
     @retry(
         retry=retry_if_exception_type(_litellm_RateLimitError),
@@ -1254,19 +1252,16 @@ class LiteLLMTranslator(BaseTranslator):
         completion_kwargs = {
             "model": self.model,
             "messages": self.prompt(text, self.prompttext),
-            "stream": self.stream,
+            "stream": True,
             "drop_params": True,
             **self.options,
         }
         response = _litellm.completion(**completion_kwargs)
-        if self.stream:
-            collected = []
-            for chunk in response:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    collected.append(chunk.choices[0].delta.content)
-            content = "".join(collected).strip()
-        else:
-            content = response.choices[0].message.content.strip()
+        collected = []
+        for chunk in response:
+            if chunk.choices and chunk.choices[0].delta.content:
+                collected.append(chunk.choices[0].delta.content)
+        content = "".join(collected).strip()
         content = self.think_filter_regex.sub("", content).strip()
         return content
 

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -12,6 +12,14 @@ import ollama
 import openai
 import requests
 import xinference_client
+
+try:
+    import litellm as _litellm
+
+    _litellm_RateLimitError = _litellm.RateLimitError
+except ImportError:
+    _litellm = None
+    _litellm_RateLimitError = Exception
 from azure.ai.translation.text import TextTranslationClient
 from azure.core.credentials import AzureKeyCredential
 from tencentcloud.common import credential
@@ -1196,3 +1204,86 @@ class QwenMtTranslator(OpenAITranslator):
             extra_body={"translation_options": translation_options},
         )
         return response.choices[0].message.content.strip()
+
+
+class LiteLLMTranslator(BaseTranslator):
+    # https://docs.litellm.ai/docs/
+    name = "litellm"
+    envs = {
+        "LITELLM_MODEL": "gpt-4o-mini",
+        "LITELLM_API_KEY": None,
+        "LITELLM_API_BASE": None,
+    }
+    CustomPrompt = True
+
+    def __init__(
+        self,
+        lang_in,
+        lang_out,
+        model,
+        envs=None,
+        prompt=None,
+        ignore_cache=False,
+    ):
+        if _litellm is None:
+            raise ImportError(
+                "litellm is not installed. Install it with: pip install pdf2zh[litellm]"
+            )
+        self.set_envs(envs)
+        if not model:
+            model = self.envs["LITELLM_MODEL"]
+        super().__init__(lang_in, lang_out, model, ignore_cache)
+        self.options = {"temperature": 0}
+        self.prompttext = prompt
+        self.add_cache_impact_parameters("temperature", self.options["temperature"])
+        self.add_cache_impact_parameters("prompt", self.prompt("", self.prompttext))
+        think_filter_regex = r"^<think>.+?\n*(</think>|\n)*(</think>)\n*"
+        self.add_cache_impact_parameters("think_filter_regex", think_filter_regex)
+        self.think_filter_regex = re.compile(think_filter_regex, flags=re.DOTALL)
+        stream_val = self.envs.get("LITELLM_STREAM", "true").lower()
+        self.stream = stream_val == "true"
+
+    @retry(
+        retry=retry_if_exception_type(_litellm_RateLimitError),
+        stop=stop_after_attempt(100),
+        wait=wait_exponential(multiplier=1, min=1, max=15),
+        before_sleep=lambda retry_state: logger.warning(
+            f"RateLimitError, retrying in {retry_state.next_action.sleep} seconds... "
+            f"(Attempt {retry_state.attempt_number}/100)"
+        ),
+    )
+    def do_translate(self, text) -> str:
+        completion_kwargs = {
+            "model": self.model,
+            "messages": self.prompt(text, self.prompttext),
+            "stream": self.stream,
+            "drop_params": True,
+            **self.options,
+        }
+        api_key = self.envs.get("LITELLM_API_KEY")
+        if api_key:
+            completion_kwargs["api_key"] = api_key
+        api_base = self.envs.get("LITELLM_API_BASE")
+        if api_base:
+            completion_kwargs["api_base"] = api_base
+
+        response = _litellm.completion(**completion_kwargs)
+        if self.stream:
+            collected = []
+            for chunk in response:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    collected.append(chunk.choices[0].delta.content)
+            content = "".join(collected).strip()
+        else:
+            content = response.choices[0].message.content.strip()
+        content = self.think_filter_regex.sub("", content).strip()
+        return content
+
+    def get_formular_placeholder(self, id: int):
+        return "{{v" + str(id) + "}}"
+
+    def get_rich_text_left_placeholder(self, id: int):
+        return self.get_formular_placeholder(id)
+
+    def get_rich_text_right_placeholder(self, id: int):
+        return self.get_formular_placeholder(id + 1)

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1212,7 +1212,6 @@ class LiteLLMTranslator(BaseTranslator):
     envs = {
         "LITELLM_MODEL": "gpt-4o-mini",
         "LITELLM_API_KEY": None,
-        "LITELLM_API_BASE": None,
     }
     CustomPrompt = True
 
@@ -1263,9 +1262,6 @@ class LiteLLMTranslator(BaseTranslator):
         api_key = self.envs.get("LITELLM_API_KEY")
         if api_key:
             completion_kwargs["api_key"] = api_key
-        api_base = self.envs.get("LITELLM_API_BASE")
-        if api_base:
-            completion_kwargs["api_base"] = api_base
 
         response = _litellm.completion(**completion_kwargs)
         if self.stream:

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1211,7 +1211,6 @@ class LiteLLMTranslator(BaseTranslator):
     name = "litellm"
     envs = {
         "LITELLM_MODEL": "gpt-4o-mini",
-        "LITELLM_API_KEY": None,
     }
     CustomPrompt = True
 
@@ -1259,10 +1258,6 @@ class LiteLLMTranslator(BaseTranslator):
             "drop_params": True,
             **self.options,
         }
-        api_key = self.envs.get("LITELLM_API_KEY")
-        if api_key:
-            completion_kwargs["api_key"] = api_key
-
         response = _litellm.completion(**completion_kwargs)
         if self.stream:
             collected = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ backend = [
 argostranslate = [
     "argostranslate"
 ]
+litellm = [
+    "litellm>=1.55.0,<1.85"
+]
 mcp = [
     "mcp>=1.6.0",
 ]


### PR DESCRIPTION

## Summary

- Adds LiteLLM as a new translation service provider, giving users access to 100+ LLM providers (Anthropic, Bedrock, Vertex AI, Cohere, Mistral, etc.) through a single unified interface.
- Follows the existing translator class pattern. Drop-in, no changes to existing providers.

## Motivation

PDFMathTranslate currently supports individual providers (OpenAI, Gemini, Groq, Deepseek, etc.), each requiring a separate translator class. LiteLLM is a lightweight Python SDK that provides a unified `completion()` interface across 100+ providers. Users specify the provider via the model string (e.g. `anthropic/claude-sonnet-4-5`, `bedrock/anthropic.claude-v2`, `vertex_ai/gemini-pro`) and LiteLLM routes the call to the correct provider API. This eliminates the need to add individual translator classes for each new provider.

## Changes

- `pdf2zh/translator.py` - new `LiteLLMTranslator` class extending `BaseTranslator`
- `pdf2zh/converter.py` - registered in import list and translator loop
- `pdf2zh/gui.py` - registered in import, `service_map`, `babeldoc_translate_file` loop, and `isinstance` check for rich text support
- `pdf2zh/pdf2zh.py` - registered in import and translator loop
- `pyproject.toml` - added `litellm>=1.55.0,<1.85` as optional dependency (`pip install pdf2zh[litellm]`)

## Implementation details

- **Optional dependency**: `litellm` is an optional extra (like `argostranslate`), so the base install is unaffected. Lazy-imported with a clear error message if not installed.
- **`drop_params=True`**: Silently drops provider-unsupported kwargs (e.g. `strict`, `seed`), preventing cross-provider failures.
- **Streaming**: Always enabled, matching `OpenAITranslator` behavior.
- **Retry on rate limits**: Uses `tenacity` with exponential backoff on `litellm.RateLimitError`.
- **Think-tag filtering**: Strips `<think>` tags from reasoning model outputs (DeepSeek-R1, QwQ, etc.).
- **Rich text support**: Enabled in babeldoc mode via `isinstance` check alongside `OpenAITranslator`.
- **Provider auth**: LiteLLM reads provider-specific env vars automatically (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, etc.). 

## Service table entry

| Service | Name | Env vars | Defaults | Reference |
|---------|------|----------|----------|-----------|
| **LiteLLM** | `litellm` | `LITELLM_MODEL` + provider-specific keys (e.g. `ANTHROPIC_API_KEY`) | `gpt-4o-mini` | See [LiteLLM Providers](https://docs.litellm.ai/docs/providers) |

## Example usage

Use `-s litellm:model` to specify the provider and model:

```bash
pip install pdf2zh[litellm]

# Translate using Anthropic Claude
export ANTHROPIC_API_KEY="sk-..."
pdf2zh example.pdf -s litellm:anthropic/claude-sonnet-4-5

# Translate using AWS Bedrock
export AWS_ACCESS_KEY_ID="..." AWS_SECRET_ACCESS_KEY="..." AWS_REGION_NAME="us-east-1"
pdf2zh example.pdf -s litellm:bedrock/anthropic.claude-v2

# Translate using Google Vertex AI
export VERTEX_PROJECT="my-project" VERTEX_LOCATION="us-central1"
pdf2zh example.pdf -s litellm:vertex_ai/gemini-pro
```

Or specify the model with environment variables:

```bash
export LITELLM_MODEL=anthropic/claude-sonnet-4-5
export ANTHROPIC_API_KEY="sk-..."
pdf2zh example.pdf -s litellm
```

**GUI:** Select "LiteLLM" from the service dropdown, set `LITELLM_MODEL` to your desired model string (e.g. `anthropic/claude-sonnet-4-5`). Set the provider's API key as an environment variable before launching the GUI.

## Tests

**Live E2E test** against Anthropic Claude (`anthropic/claude-sonnet-4-5`):

```python
>>> t = LiteLLMTranslator('en', 'zh', 'anthropic/claude-sonnet-4-5')
>>> t.do_translate('Hello world')
'你好世界'

>>> t.do_translate('Machine learning is transforming the world.')
'机器学习正在改变世界。'

>>> t.do_translate('The equation {{v0}} shows that {{v1}} is proportional to {{v2}}.')
'方程 {{v0}} 表明 {{v1}} 与 {{v2}} 成正比。'
```

Formula placeholders (`{{v0}}`, `{{v1}}`, `{{v2}}`) are preserved correctly in translated output.

## Risk / Compatibility

- Additive only. Existing providers untouched.
- `litellm` is an optional extra. Base install unaffected.
- Pinned to `>=1.55.0,<1.85` for stability.
