### PR TITLE
fix: guard against empty choices and message=None in OpenAI responses

### DIFF
--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -546,6 +546,8 @@ class AzureOpenAITranslator(BaseTranslator):
             **self.options,
             messages=self.prompt(text, self.prompttext),
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content.strip()
 
 
@@ -622,12 +624,16 @@ class ZhipuTranslator(OpenAITranslator):
                 messages=self.prompt(text, self.prompttext),
             )
         except openai.BadRequestError as e:
+            if not response.choices or response.choices[0].message is None:
+                raise ValueError("LLM returned empty or filtered response") from e
             if (
                 json.loads(response.choices[0].message.content.strip())["error"]["code"]
                 == "1301"
             ):
                 return "IRREPARABLE TRANSLATION ERROR"
             raise e
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content.strip()
 
 
@@ -1195,4 +1201,6 @@ class QwenMtTranslator(OpenAITranslator):
             messages=[{"role": "user", "content": text}],
             extra_body={"translation_options": translation_options},
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content.strip()


### PR DESCRIPTION
## Problem

OpenAI-compatible APIs can fail silently in two ways:

1. **Empty choices list** (`IndexError`): `response.choices` is `[]` when the API returns no completions
2. **`message=None`** (`AttributeError`): `response.choices[0].message` is `None` when content is filtered (e.g., Gemini returns HTTP 200 with `PROHIBITED_CONTENT`, `message=None`)

Both paths cause unhandled runtime exceptions during translation, aborting the entire translation job.

## Affected code

Three `Translator` subclasses in `pdf2zh/translator.py` have unguarded accesses (4 sites total — lines 549, 628, 631, 1198 in the original).

## Fix

Adds the standard two-condition guard before each bare `choices[0].message.content` access:

```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
```

This converts silent crashes into explicit, actionable errors with a clear message.

**8 lines added, 0 deleted.**

## Verification

Detected by [pact](https://github.com/qizwiz/pact) static analysis (`llm_response_unguarded` rule). Confirmed: Gemini 2.5 Flash returns HTTP 200 with `choices[0].message=None` on prohibited content.