### PR TITLE
Fix three reliability issues: request hangs, infinite retries, malformed PDFs

### DIFF
--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import logging
+import os
 import re
 import unicodedata
 from enum import Enum
@@ -13,7 +14,7 @@ from pdfminer.pdffont import PDFCIDFont, PDFUnicodeNotDefined
 from pdfminer.pdfinterp import PDFGraphicState, PDFResourceManager
 from pdfminer.utils import apply_matrix_pt, mult_matrix
 from pymupdf import Font
-from tenacity import retry, wait_fixed
+from tenacity import retry, wait_fixed, stop_after_attempt
 
 from pdf2zh.translator import (
     AnythingLLMTranslator,
@@ -345,7 +346,15 @@ class TranslateConverter(PDFConverterEx):
         # B. 段落翻译
         log.debug("\n==========[SSTACK]==========\n")
 
-        @retry(wait=wait_fixed(1))
+        # 重试次数上限,避免某段落持续失败导致整篇无限重试卡死;
+        # 用尽后由 retry_error_callback 回退为原文,保证整篇仍能产出
+        max_attempts = int(os.environ.get("PDF2ZH_TRANSLATE_RETRIES", "5"))
+
+        @retry(
+            wait=wait_fixed(1),
+            stop=stop_after_attempt(max_attempts),
+            retry_error_callback=lambda retry_state: retry_state.args[0],
+        )
         def worker(s: str):  # 多线程翻译
             if not s.strip() or re.match(r"^\{v\d+\}$", s):  # 空白和公式不翻译
                 return s

--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -194,8 +194,21 @@ def translate_stream(
     font_list.append((noto_name, font_path))
 
     doc_en = Document(stream=stream)
-    stream = io.BytesIO()
-    doc_en.save(stream)
+    out_stream = io.BytesIO()
+    try:
+        doc_en.save(out_stream)
+    except Exception as e:
+        # 输入 PDF 结构损坏导致 MuPDF 无法重写时,用 pikepdf(qpdf)修复后重试
+        logger.warning(f"Malformed input PDF ({e}); repairing with pikepdf")
+        from pikepdf import Pdf
+
+        repaired = io.BytesIO()
+        with Pdf.open(io.BytesIO(stream)) as _pdf:
+            _pdf.save(repaired)
+        doc_en = Document(stream=repaired.getvalue())
+        out_stream = io.BytesIO()
+        doc_en.save(out_stream)
+    stream = out_stream
     doc_zh = Document(stream=stream)
     page_count = doc_zh.page_count
     # font_list = [("GoNotoKurrent-Regular.ttf", font_path), ("tiro", None)]

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -447,6 +447,9 @@ class OpenAITranslator(BaseTranslator):
         self.client = openai.OpenAI(
             base_url=base_url or self.envs["OPENAI_BASE_URL"],
             api_key=api_key or self.envs["OPENAI_API_KEY"],
+            # 防止单个请求静默挂起导致整篇卡死;超时后由上层重试自愈
+            timeout=float(os.environ.get("PDF2ZH_OPENAI_TIMEOUT", "120")),
+            max_retries=2,
         )
         self.prompttext = prompt
         self.add_cache_impact_parameters("temperature", self.options["temperature"])


### PR DESCRIPTION
## Summary

Three independent robustness fixes found while translating real-world PDFs with the `deepseek`/`openai` services. Each one could make a run hang forever or crash outright. All three are validated end-to-end (a 114-page and a 47-page paper now translate cleanly; the 47-page one previously hung 100% of the time on its last page).

## Changes

### 1. `translator.py` — add a request timeout to the OpenAI client
`openai.OpenAI(...)` was created without a `timeout`, so a single request that silently stalls (network blip / unresponsive endpoint) blocks the entire document indefinitely (0% CPU, no error, no progress). Added `timeout` (default `120s`, override via `PDF2ZH_OPENAI_TIMEOUT`) and `max_retries=2`, so a stalled request fails fast and is retried instead of hanging forever.

### 2. `converter.py` — bound paragraph translation retries
`worker()` used `@retry(wait=wait_fixed(1))` with **no stop condition**, so a permanently-failing paragraph retried every second forever and the whole run got stuck. Added `stop_after_attempt` (default `5`, override via `PDF2ZH_TRANSLATE_RETRIES`) and a `retry_error_callback` that falls back to the source text on exhaustion, so the document still completes instead of stalling.

### 3. `high_level.py` — auto-repair malformed input PDFs
Some structurally broken PDFs make MuPDF raise during the initial `doc_en.save()` (`cannot parse object (N 0 R)`), aborting before translation even starts. Caught that failure and repaired the input with `pikepdf` (already a dependency, already imported in this module) before retrying.

## Notes
- All three are opt-out-safe: behavior is unchanged on healthy inputs, and the two new knobs are environment variables with sensible defaults.
- No new dependencies (`pikepdf` was already required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)