### PR TITLE
feat: mirror source directory tree in batch translation output

### DIFF
--- a/pdf2zh/high_level.py
+++ b/pdf2zh/high_level.py
@@ -319,6 +319,7 @@ def translate(
     prompt: Template = None,
     skip_subset_fonts: bool = False,
     ignore_cache: bool = False,
+    source_dir: str = "",
     **kwarg: Any,
 ):
     if not files:
@@ -335,6 +336,7 @@ def translate(
     result_files = []
 
     for file in files:
+        original_file = file
         if type(file) is str and (
             file.startswith("http://") or file.startswith("https://")
         ):
@@ -394,8 +396,14 @@ def translate(
             s_raw,
             **locals(),
         )
-        file_mono = Path(output) / f"{filename}-mono.pdf"
-        file_dual = Path(output) / f"{filename}-dual.pdf"
+        if output and source_dir and not str(original_file).startswith(("http://", "https://")):
+            rel_dir = Path(os.path.relpath(original_file, source_dir)).parent
+            out_subdir = Path(output) / rel_dir
+            out_subdir.mkdir(parents=True, exist_ok=True)
+        else:
+            out_subdir = Path(output)
+        file_mono = out_subdir / f"{filename}-mono.pdf"
+        file_dual = out_subdir / f"{filename}-dual.pdf"
         doc_mono = open(file_mono, "wb")
         doc_dual = open(file_dual, "wb")
         doc_mono.write(s_mono)

--- a/pdf2zh/kernel/legacy.py
+++ b/pdf2zh/kernel/legacy.py
@@ -68,6 +68,9 @@ class LegacyKernel:
 
             kwargs["prompt"] = Template(request.prompt)
 
+        if request.source_dir:
+            kwargs["source_dir"] = request.source_dir
+
         result_files = translate(**kwargs)
 
         results = []

--- a/pdf2zh/kernel/protocol.py
+++ b/pdf2zh/kernel/protocol.py
@@ -27,6 +27,7 @@ class TranslateRequest:
     skip_subset_fonts: bool = False
     ignore_cache: bool = False
     compatible: bool = False
+    source_dir: Optional[str] = None
 
 
 @dataclass

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -343,8 +343,10 @@ def main(args: Optional[List[str]] = None) -> int:
     KernelRegistry.switch(parsed_args.mode)  # "fast" or "precise"
     kernel = KernelRegistry.get()
 
+    source_dir = ""
     if parsed_args.dir:
-        parsed_args.files = find_all_files_in_directory(parsed_args.files[0])
+        source_dir = os.path.abspath(parsed_args.files[0])
+        parsed_args.files = find_all_files_in_directory(source_dir)
 
     # Extract prompt text (may be a Template object from file reading above)
     prompt_text = None
@@ -371,6 +373,7 @@ def main(args: Optional[List[str]] = None) -> int:
         ignore_cache=parsed_args.ignore_cache,
         compatible=parsed_args.compatible,
         debug=parsed_args.debug,
+        source_dir=source_dir,
     )
     kernel.translate(request)
     return 0


### PR DESCRIPTION
## Summary

Closes #793.

When `--dir` is used, translated files now land in a subdirectory structure that mirrors the source tree instead of being flattened into the output root.

**Example:**
```
docs/
  papers/intro.pdf
  supplemental/appendix.pdf
```
With `pdf2zh --dir docs/ -o out/` you now get:
```
out/
  papers/intro-mono.pdf
  papers/intro-dual.pdf
  supplemental/appendix-mono.pdf
  supplemental/appendix-dual.pdf
```

## What changed

- `TranslateRequest` (`kernel/protocol.py`): added `source_dir: Optional[str] = None` field
- `LegacyKernel.translate()` (`kernel/legacy.py`): passes `source_dir` through to `high_level.translate()` when set
- `high_level.translate()` (`high_level.py`): accepts `source_dir` kwarg; computes a relative output subdir per file using `os.path.relpath`, creates it with `mkdir(parents=True)`, skips the logic for URL inputs
- `main()` (`pdf2zh.py`): captures `source_dir = os.path.abspath(files[0])` before expanding the file list, passes it into `TranslateRequest`

URL inputs and non-`--dir` invocations are unaffected — they continue writing directly to `Path(output)`.

## Test plan

- [ ] `pdf2zh --dir /path/to/nested/ -o /tmp/out/` — verify output mirrors source hierarchy
- [ ] Single-file invocation `pdf2zh paper.pdf -o /tmp/out/` — verify flat output unchanged
- [ ] URL input (`pdf2zh https://…/paper.pdf -o /tmp/out/`) — verify flat output unchanged