### PR TITLE
Add Thai GUI language option

### DIFF
--- a/docs/README_GUI.md
+++ b/docs/README_GUI.md
@@ -29,6 +29,7 @@ The following languages are supported:
 - Russian
 - Spanish
 - Italian
+- Thai
 
 ## Preview
 

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -110,6 +110,7 @@ lang_map = {
     "Russian": "ru",
     "Spanish": "es",
     "Italian": "it",
+    "Thai": "th",
 }
 
 # The following variable associate strings with page ranges

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -1175,6 +1175,7 @@ class QwenMtTranslator(OpenAITranslator):
             "ru": "Russian",
             "es": "Spanish",
             "it": "Italian",
+            "th": "Thai",
         }
 
         return langdict[input_lang]

--- a/test/test_gui_languages.py
+++ b/test/test_gui_languages.py
@@ -1,0 +1,25 @@
+import ast
+from pathlib import Path
+
+
+def _load_gui_lang_map() -> dict[str, str]:
+    gui_path = Path(__file__).resolve().parents[1] / "pdf2zh" / "gui.py"
+    module = ast.parse(gui_path.read_text(encoding="utf-8"))
+
+    for node in module.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "lang_map":
+                    return ast.literal_eval(node.value)
+
+    raise AssertionError("lang_map not found in pdf2zh/gui.py")
+
+
+def test_gui_language_map_includes_thai():
+    assert _load_gui_lang_map()["Thai"] == "th"
+
+
+def test_qwen_mt_maps_thai_language_code():
+    from pdf2zh.translator import QwenMtTranslator
+
+    assert QwenMtTranslator.lang_mapping("th") == "Thai"


### PR DESCRIPTION
Summary:
- Adds Thai to the GUI language dropdown as `th`.
- Adds the Qwen-MT language mapping for Thai.
- Updates GUI documentation and adds a focused language-map test.

Testing:
- python3 -m compileall -q pdf2zh test/test_gui_languages.py
- python3 standard-library assertions for Thai GUI/Qwen/doc entries
- Not run: `python3 -m pytest test/test_gui_languages.py` because pytest is not installed in this local environment.

Fixes #1151

AI assistance: This enhancement was prepared with AI assistance and reviewed before submission.
