### PR TITLE
feat(translator): add Claude Code CLI backend

### DIFF
--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -77,6 +77,7 @@ We've provided a detailed table on the required [environment variables](https://
 |**MiniMax**|`minimax`| `MINIMAX_API_KEY`, `MINIMAX_MODEL` | `[Your MINIMAX_API_KEY]`, `MiniMax-M2.7` |See [MiniMax](https://platform.minimaxi.com/)|
 |**OpenAI-Liked**|`openailiked`| `OPENAILIKED_BASE_URL`, `OPENAILIKED_API_KEY`, `OPENAILIKED_MODEL` | `url`, `[Your Key]`, `model name` | None |
 |**OpenAI-Liked**|`openailiked`| `OPENAILIKED_BASE_URL`, `OPENAILIKED_API_KEY`, `OPENAILIKED_MODEL`, `OPENAILIKED_STOP_TOKENS`, `OPENAILIKED_MAX_TOKENS` | `url`, `[Your Key]`, `model name`, ` `, `-1` | None |
+|**Claude Code**|`claude-code`| `CLAUDE_CODE_BIN`, `CLAUDE_CODE_MODEL`, `CLAUDE_CODE_TIMEOUT` | `claude`, `sonnet`, `120` | Uses the authenticated local Claude Code CLI; no API key is required. Translation batches are bounded and effective concurrency is limited to `1`. |
 |**Ali Qwen Translation**|`qwen-mt`| `ALI_MODEL`, `ALI_API_KEY`, `ALI_DOMAINS` | `qwen-mt-turbo`, `[Your Key]`, `scientific paper` | Tranditional Chinese are not yet supported, it will be translated into Simplified Chinese. More see [Qwen MT](https://bailian.console.aliyun.com/?spm=5176.28197581.0.0.72e329a4HRxe99#/model-market/detail/qwen-mt-turbo) |
 
 For large language models that are compatible with the OpenAI API but not listed in the table above, you can set environment variables using the same method outlined for OpenAI in the table.
@@ -86,6 +87,17 @@ Use `-s service` or `-s service:model` to specify service:
 ```bash
 pdf2zh example.pdf -s openai:gpt-4o-mini
 ```
+
+Claude Code can use its current login without an API key:
+
+```bash
+claude --version
+pdf2zh example.pdf -s claude-code:sonnet
+```
+
+`CLAUDE_CODE_TIMEOUT` is measured in seconds. The CLI is invoked without tools,
+project/user setting sources, or session persistence, and its structured output
+is validated before it is cached.
 
 Or specify model with environment variables:
 

--- a/pdf2zh/converter.py
+++ b/pdf2zh/converter.py
@@ -22,6 +22,7 @@ from pdf2zh.translator import (
     AzureTranslator,
     BaseTranslator,
     BingTranslator,
+    ClaudeCodeTranslator,
     DeepLTranslator,
     DeepLXTranslator,
     DeepseekTranslator,
@@ -161,11 +162,58 @@ class TranslateConverter(PDFConverterEx):
         if not envs:
             envs = {}
         for translator in [GoogleTranslator, BingTranslator, DeepLTranslator, DeepLXTranslator, OllamaTranslator, XinferenceTranslator, AzureOpenAITranslator,
-                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, QwenMtTranslator, X302AITranslator]:
+                           OpenAITranslator, ZhipuTranslator, ModelScopeTranslator, SiliconTranslator, GeminiTranslator, AzureTranslator, TencentTranslator, DifyTranslator, AnythingLLMTranslator, ArgosTranslator, GrokTranslator, GroqTranslator, DeepseekTranslator, MiniMaxTranslator, OpenAIlikedTranslator, ClaudeCodeTranslator, QwenMtTranslator, X302AITranslator]:
             if service_name == translator.name:
                 self.translator = translator(lang_in, lang_out, service_model, envs=envs, prompt=prompt, ignore_cache=ignore_cache)
         if not self.translator:
             raise ValueError("Unsupported translation service")
+
+    @staticmethod
+    def _is_passthrough_text(text: str) -> bool:
+        return not text.strip() or re.match(r"^\{v\d+\}$", text) is not None
+
+    def _translate_text_segments(self, texts: list[str]) -> list[str]:
+        @retry(wait=wait_fixed(1))
+        def worker(text: str):
+            if self._is_passthrough_text(text):
+                return text
+            try:
+                return self.translator.translate(text)
+            except BaseException as exc:
+                if log.isEnabledFor(logging.DEBUG):
+                    log.exception(exc)
+                else:
+                    log.exception(exc, exc_info=False)
+                raise
+
+        if self.translator.batch_size > 1:
+            results = list(texts)
+            indices = [
+                index
+                for index, text in enumerate(texts)
+                if not self._is_passthrough_text(text)
+            ]
+            if not indices:
+                return results
+
+            batch = [texts[index] for index in indices]
+            translated = self.translator.translate_batch(batch)
+            if len(translated) != len(batch):
+                raise ValueError("translator returned an invalid batch size")
+            for index, translation in zip(indices, translated):
+                results[index] = translation
+            return results
+
+        max_workers = self.thread
+        if self.translator.max_concurrency is not None:
+            max_workers = min(
+                max_workers or self.translator.max_concurrency,
+                self.translator.max_concurrency,
+            )
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max_workers
+        ) as executor:
+            return list(executor.map(worker, texts))
 
     def receive_layout(self, ltpage: LTPage):
         # 段落
@@ -345,23 +393,7 @@ class TranslateConverter(PDFConverterEx):
         # B. 段落翻译
         log.debug("\n==========[SSTACK]==========\n")
 
-        @retry(wait=wait_fixed(1))
-        def worker(s: str):  # 多线程翻译
-            if not s.strip() or re.match(r"^\{v\d+\}$", s):  # 空白和公式不翻译
-                return s
-            try:
-                new = self.translator.translate(s)
-                return new
-            except BaseException as e:
-                if log.isEnabledFor(logging.DEBUG):
-                    log.exception(e)
-                else:
-                    log.exception(e, exc_info=False)
-                raise e
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=self.thread
-        ) as executor:
-            news = list(executor.map(worker, sstk))
+        news = self._translate_text_segments(sstk)
 
         ############################################################
         # C. 新文档排版

--- a/pdf2zh/gui.py
+++ b/pdf2zh/gui.py
@@ -25,6 +25,7 @@ from pdf2zh.translator import (
     AzureTranslator,
     BaseTranslator,
     BingTranslator,
+    ClaudeCodeTranslator,
     DeepLTranslator,
     DeepLXTranslator,
     DifyTranslator,
@@ -94,6 +95,7 @@ service_map: dict[str, BaseTranslator] = {
     "DeepSeek": DeepseekTranslator,
     "MiniMax": MiniMaxTranslator,
     "OpenAI-liked": OpenAIlikedTranslator,
+    "Claude Code": ClaudeCodeTranslator,
     "Ali Qwen-Translation": QwenMtTranslator,
     "302.AI": X302AITranslator,
 }
@@ -332,6 +334,8 @@ def translate_file(
         threads = int(threads)
     except ValueError:
         threads = 1
+    if translator.max_concurrency is not None:
+        threads = min(threads, translator.max_concurrency)
 
     param = {
         "files": [str(file_raw)],
@@ -425,6 +429,7 @@ def babeldoc_translate_file(**kwargs):
         GroqTranslator,
         DeepseekTranslator,
         OpenAIlikedTranslator,
+        ClaudeCodeTranslator,
         QwenMtTranslator,
         X302AITranslator,
     ]:
@@ -459,7 +464,9 @@ def babeldoc_translate_file(**kwargs):
             no_mono=False,
             qps=kwargs["thread"],
             use_rich_pbar=False,
-            disable_rich_text_translate=not isinstance(translator, OpenAITranslator),
+            disable_rich_text_translate=not isinstance(
+                translator, (OpenAITranslator, ClaudeCodeTranslator)
+            ),
             skip_clean=kwargs["skip_subset_fonts"],
             report_interval=0.5,
         )

--- a/pdf2zh/pdf2zh.py
+++ b/pdf2zh/pdf2zh.py
@@ -417,6 +417,7 @@ def yadt_main(parsed_args) -> int:
         AzureOpenAITranslator,
         GoogleTranslator,
         BingTranslator,
+        ClaudeCodeTranslator,
         DeepLTranslator,
         DeepLXTranslator,
         OllamaTranslator,
@@ -461,6 +462,7 @@ def yadt_main(parsed_args) -> int:
         GroqTranslator,
         DeepseekTranslator,
         OpenAIlikedTranslator,
+        ClaudeCodeTranslator,
         QwenMtTranslator,
         X302AITranslator,
     ]:
@@ -496,7 +498,11 @@ def yadt_main(parsed_args) -> int:
             lang_out=lang_out,
             no_dual=False,
             no_mono=False,
-            qps=parsed_args.thread,
+            qps=(
+                min(parsed_args.thread, translator.max_concurrency)
+                if translator.max_concurrency is not None
+                else parsed_args.thread
+            ),
         )
 
         async def yadt_translate_coro(yadt_config):

--- a/pdf2zh/translator.py
+++ b/pdf2zh/translator.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import re
+import subprocess
+import tempfile
 import unicodedata
 from copy import copy
 from string import Template
@@ -41,6 +43,8 @@ class BaseTranslator:
     envs = {}
     lang_map: dict[str, str] = {}
     CustomPrompt = False
+    batch_size = 1
+    max_concurrency: int | None = None
 
     def __init__(self, lang_in: str, lang_out: str, model: str, ignore_cache: bool):
         lang_in = self.lang_map.get(lang_in.lower(), lang_in)
@@ -100,6 +104,12 @@ class BaseTranslator:
         translation = self.do_translate(text)
         self.cache.set(text, translation)
         return translation
+
+    def translate_batch(
+        self, texts: list[str], ignore_cache: bool = False
+    ) -> list[str]:
+        """Translate a batch while preserving the existing per-item cache contract."""
+        return [self.translate(text, ignore_cache=ignore_cache) for text in texts]
 
     def do_translate(self, text: str) -> str:
         """
@@ -1196,3 +1206,217 @@ class QwenMtTranslator(OpenAITranslator):
             extra_body={"translation_options": translation_options},
         )
         return response.choices[0].message.content.strip()
+
+
+class ClaudeCodeTranslator(BaseTranslator):
+    """Translate with an authenticated local Claude Code CLI session."""
+
+    name = "claude-code"
+    envs = {
+        "CLAUDE_CODE_BIN": "claude",
+        "CLAUDE_CODE_MODEL": "sonnet",
+        "CLAUDE_CODE_TIMEOUT": "120",
+    }
+    CustomPrompt = True
+    batch_size = 8
+    max_batch_chars = 6000
+    max_concurrency = 1
+    placeholder_pattern = re.compile(r"(?:\{v\d+\}|</?b\d+>)")
+
+    single_schema = {
+        "type": "object",
+        "properties": {"translation": {"type": "string"}},
+        "required": ["translation"],
+        "additionalProperties": False,
+    }
+    batch_schema = {
+        "type": "object",
+        "properties": {
+            "translations": {
+                "type": "array",
+                "items": {"type": "string"},
+            }
+        },
+        "required": ["translations"],
+        "additionalProperties": False,
+    }
+
+    def __init__(
+        self, lang_in, lang_out, model, envs=None, prompt=None, ignore_cache=False
+    ):
+        self.set_envs(envs)
+        model = model or self.envs["CLAUDE_CODE_MODEL"]
+        super().__init__(lang_in, lang_out, model, ignore_cache)
+        self.claude_bin = self.envs["CLAUDE_CODE_BIN"] or "claude"
+        self.timeout = self._parse_timeout(self.envs["CLAUDE_CODE_TIMEOUT"])
+        self.prompttext = prompt
+        self.add_cache_impact_parameters("prompt", str(prompt or ""))
+
+    @staticmethod
+    def _parse_timeout(value) -> float:
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("CLAUDE_CODE_TIMEOUT must be a positive number") from exc
+        if timeout <= 0:
+            raise ValueError("CLAUDE_CODE_TIMEOUT must be a positive number")
+        return timeout
+
+    def _command(self, schema: dict) -> list[str]:
+        return [
+            self.claude_bin,
+            "-p",
+            "--model",
+            self.model,
+            "--setting-sources",
+            "",
+            "--tools",
+            "",
+            "--no-session-persistence",
+            "--output-format",
+            "json",
+            "--json-schema",
+            json.dumps(schema, separators=(",", ":")),
+        ]
+
+    @retry(
+        retry=retry_if_exception_type(
+            (OSError, subprocess.TimeoutExpired, RuntimeError, ValueError)
+        ),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=4),
+        reraise=True,
+    )
+    def _run_cli(self, prompt: str, schema: dict) -> dict:
+        try:
+            with tempfile.TemporaryDirectory(prefix="pdf2zh-claude-code-") as cwd:
+                completed = subprocess.run(
+                    self._command(schema),
+                    input=prompt,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout,
+                    check=False,
+                    cwd=cwd,
+                )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                f"Claude Code executable not found: {self.claude_bin}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"Claude Code timed out after {self.timeout:g} seconds"
+            ) from exc
+
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(
+                f"Claude Code exited with status {completed.returncode}: "
+                f"{detail[:1000]}"
+            )
+
+        try:
+            envelope = json.loads(completed.stdout)
+            output = envelope["structured_output"]
+            if isinstance(output, str):
+                output = json.loads(output)
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise ValueError("Claude Code returned invalid structured output") from exc
+        if not isinstance(output, dict):
+            raise ValueError("Claude Code structured output must be an object")
+        return output
+
+    def _translation_prompt(self, text: str) -> str:
+        instruction = self.prompt(text, self.prompttext)[0]["content"]
+        return (
+            f"{instruction}\n\n"
+            "Return the result through the provided JSON schema. Preserve every "
+            "formula and placeholder token such as {v0}, <b0>, and </b0> exactly."
+        )
+
+    def _validate_translation(self, source: str, translation) -> str:
+        if not isinstance(translation, str) or not translation.strip():
+            raise ValueError("Claude Code returned an empty translation")
+        source_placeholders = sorted(self.placeholder_pattern.findall(source))
+        translated_placeholders = sorted(self.placeholder_pattern.findall(translation))
+        if source_placeholders != translated_placeholders:
+            raise ValueError("Claude Code changed formula or rich-text placeholders")
+        return translation.strip()
+
+    def do_translate(self, text: str) -> str:
+        output = self._run_cli(self._translation_prompt(text), self.single_schema)
+        return self._validate_translation(text, output.get("translation"))
+
+    def _translate_uncached_batch(self, texts: list[str]) -> list[str]:
+        items = [
+            {
+                "index": index,
+                "instruction": self.prompt(text, self.prompttext)[0]["content"],
+            }
+            for index, text in enumerate(texts)
+        ]
+        prompt = (
+            f"Translate all {len(texts)} items below independently. Return exactly "
+            f"{len(texts)} strings in index order through the provided JSON schema. "
+            "Preserve every formula and placeholder token such as {v0}, <b0>, "
+            "and </b0> exactly. Do not merge or reorder items.\n\n"
+            f"Items: {json.dumps(items, ensure_ascii=False)}"
+        )
+        output = self._run_cli(prompt, self.batch_schema)
+        translations = output.get("translations")
+        if not isinstance(translations, list) or len(translations) != len(texts):
+            raise ValueError(
+                "Claude Code returned a different number of batch translations"
+            )
+        return [
+            self._validate_translation(source, translation)
+            for source, translation in zip(texts, translations)
+        ]
+
+    def _chunks(self, texts: list[str]):
+        chunk: list[str] = []
+        char_count = 0
+        for text in texts:
+            if chunk and (
+                len(chunk) >= self.batch_size
+                or char_count + len(text) > self.max_batch_chars
+            ):
+                yield chunk
+                chunk = []
+                char_count = 0
+            chunk.append(text)
+            char_count += len(text)
+        if chunk:
+            yield chunk
+
+    def translate_batch(
+        self, texts: list[str], ignore_cache: bool = False
+    ) -> list[str]:
+        results: list[str | None] = [None] * len(texts)
+        missing_indices: list[int] = []
+        missing_texts: list[str] = []
+
+        for index, text in enumerate(texts):
+            cached = None
+            if not (self.ignore_cache or ignore_cache):
+                cached = self.cache.get(text)
+            if cached is None:
+                missing_indices.append(index)
+                missing_texts.append(text)
+            else:
+                results[index] = cached
+
+        offset = 0
+        for chunk in self._chunks(missing_texts):
+            translations = self._translate_uncached_batch(chunk)
+            for text, translation in zip(chunk, translations):
+                index = missing_indices[offset]
+                results[index] = translation
+                self.cache.set(text, translation)
+                offset += 1
+
+        if any(result is None for result in results):
+            raise RuntimeError(
+                "Claude Code batch translation produced incomplete results"
+            )
+        return cast(list[str], results)

--- a/test/test_converter.py
+++ b/test/test_converter.py
@@ -105,6 +105,35 @@ class TestTranslateConverter(unittest.TestCase):
                 service="InvalidService",
             )
 
+    def test_claude_code_translator_initialization(self):
+        converter = TranslateConverter(
+            self.rsrcmgr,
+            layout=self.layout,
+            lang_in="en",
+            lang_out="ja",
+            service="claude-code:sonnet",
+            envs={
+                "CLAUDE_CODE_BIN": "claude",
+                "CLAUDE_CODE_MODEL": "sonnet",
+                "CLAUDE_CODE_TIMEOUT": "120",
+            },
+        )
+        self.assertEqual(converter.translator.name, "claude-code")
+        self.assertEqual(converter.translator.model, "sonnet")
+        self.assertEqual(converter.translator.max_concurrency, 1)
+
+    def test_batch_translation_preserves_passthrough_segments(self):
+        translator = Mock()
+        translator.batch_size = 8
+        translator.max_concurrency = 1
+        translator.translate_batch.return_value = ["一", "二"]
+        self.converter.translator = translator
+
+        result = self.converter._translate_text_segments(["one", "", "{v0}", "two"])
+
+        self.assertEqual(result, ["一", "", "{v0}", "二"])
+        translator.translate_batch.assert_called_once_with(["one", "two"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_translator.py
+++ b/test/test_translator.py
@@ -1,4 +1,5 @@
 import unittest
+import json
 from textwrap import dedent
 from unittest import mock
 
@@ -6,7 +7,12 @@ from ollama import ResponseError as OllamaResponseError
 
 from pdf2zh import cache
 from pdf2zh.config import ConfigManager
-from pdf2zh.translator import BaseTranslator, OllamaTranslator, OpenAIlikedTranslator
+from pdf2zh.translator import (
+    BaseTranslator,
+    ClaudeCodeTranslator,
+    OllamaTranslator,
+    OpenAIlikedTranslator,
+)
 
 # Since it is necessary to test whether the functionality meets the expected requirements,
 # private functions and private methods are allowed to be called.
@@ -81,6 +87,81 @@ class TestTranslator(unittest.TestCase):
         translator = BaseTranslator("en", "zh", "test", False)
         with self.assertRaises(NotImplementedError):
             translator.translate("Hello World")
+
+
+class TestClaudeCodeTranslator(unittest.TestCase):
+    def setUp(self):
+        ConfigManager.clear()
+        self.test_db = cache.init_test_db()
+        self.envs = {
+            "CLAUDE_CODE_BIN": "claude-test",
+            "CLAUDE_CODE_MODEL": "sonnet",
+            "CLAUDE_CODE_TIMEOUT": "15",
+        }
+
+    def tearDown(self):
+        cache.clean_test_db(self.test_db)
+        ConfigManager.clear()
+
+    def translator(self):
+        return ClaudeCodeTranslator(
+            "en", "ja", None, envs=self.envs, ignore_cache=False
+        )
+
+    @mock.patch("pdf2zh.translator.subprocess.run")
+    def test_command_and_structured_output(self, run):
+        run.return_value = mock.Mock(
+            returncode=0,
+            stdout=json.dumps({"structured_output": {"translation": "翻訳 {v0}"}}),
+            stderr="",
+        )
+        translator = self.translator()
+
+        result = translator.do_translate("source {v0}")
+
+        self.assertEqual(result, "翻訳 {v0}")
+        command = run.call_args.args[0]
+        self.assertEqual(command[0], "claude-test")
+        self.assertIn("-p", command)
+        self.assertIn("--no-session-persistence", command)
+        self.assertIn("--json-schema", command)
+        self.assertNotIn("shell", run.call_args.kwargs)
+        self.assertIn("source {v0}", run.call_args.kwargs["input"])
+        self.assertEqual(run.call_args.kwargs["timeout"], 15)
+
+    def test_batch_preserves_order_and_cache(self):
+        translator = self.translator()
+        translator._translate_uncached_batch = mock.Mock(return_value=["一", "二"])
+
+        first = translator.translate_batch(["one", "two"])
+        second = translator.translate_batch(["one", "two"])
+
+        self.assertEqual(first, ["一", "二"])
+        self.assertEqual(second, first)
+        translator._translate_uncached_batch.assert_called_once_with(["one", "two"])
+
+    def test_batch_rejects_wrong_result_count(self):
+        translator = self.translator()
+        translator._run_cli = mock.Mock(return_value={"translations": ["only one"]})
+        with self.assertRaisesRegex(ValueError, "different number"):
+            translator._translate_uncached_batch(["one", "two"])
+
+    def test_placeholder_validation(self):
+        translator = self.translator()
+        with self.assertRaisesRegex(ValueError, "placeholders"):
+            translator._validate_translation("source {v0}", "翻訳")
+
+    @mock.patch("pdf2zh.translator.subprocess.run", side_effect=FileNotFoundError)
+    def test_missing_binary_has_clear_error(self, _run):
+        translator = self.translator()
+        undecorated = translator._run_cli.__wrapped__
+        with self.assertRaisesRegex(RuntimeError, "executable not found"):
+            undecorated(translator, "prompt", translator.single_schema)
+
+    def test_invalid_timeout_is_rejected(self):
+        self.envs["CLAUDE_CODE_TIMEOUT"] = "never"
+        with self.assertRaisesRegex(ValueError, "positive number"):
+            self.translator()
 
 
 class TestOpenAIlikedTranslator(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Add a `claude-code` translation service that uses an authenticated local Claude Code CLI session without an API key.
- Keep this change complementary to #1124: this PR intentionally does not add or duplicate Codex support.

## Changes

- Invoke Claude Code with safe subprocess arguments and stdin, with tools, setting sources, and session persistence disabled.
- Validate schema-constrained JSON output, placeholder preservation, timeout values, and batch cardinality before caching results.
- Preserve per-item cache semantics while batching up to 8 items / 6000 source characters and limiting effective concurrency to 1.
- Register the service in the classic converter, CLI BabelDOC path, GUI, and GUI BabelDOC path.
- Add backward-compatible batch/concurrency capabilities to `BaseTranslator`; existing translators retain their current behavior.
- Document local model selection and environment variables.

## Validation

- Python 3.12: `uv run pytest -q` (84 passed, 1 skipped)
- Python 3.11: focused translator/converter tests (23 passed)
- `uv run black --check ...`
- `uv build`
- Live Claude Code structured-output smoke test using the installed authenticated CLI
